### PR TITLE
Improve SEO metadata and content quality signals

### DIFF
--- a/assets/js/postpone.js
+++ b/assets/js/postpone.js
@@ -56,13 +56,18 @@ function getJSON(url, fn) {
     if (request.status >= 200 && request.status < 400) {
       const data = JSON.parse(request.responseText);
       fn(data)
+    } else {
+      info.innerHTML = '<p class=error>{{ T "search_no_page_found" }}</p>';
     }
+  };
+  request.onerror = function () {
+    info.innerHTML = '<p class=error>{{ T "search_no_page_found" }}</p>';
   };
   request.send()
 };
 
 function executeSearch(searchQuery) {
-  getJSON('index.json', function (data) {
+  getJSON('{{ with .OutputFormats.Get "json" }}{{ .RelPermalink }}{{ else }}index.json{{ end }}', function (data) {
 
     // Limit results and throw an error if too many pages are found
     const limit = {{ .Site.Params.Search.maxResults | default 30

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Home"
 hideTitle: true
-description: "Hi there! I'm Pablo Jesús González Rubio, a Python Engineer and Web Developer based in Salamanca, Spain."
+description: "Personal website of Pablo González, Python backend engineer sharing software development guides, Linux notes, and cybersecurity writeups."
 author: "Pablo Jesús González Rubio"
 imgPath: "."
 disableTitleSeparator: false

--- a/content/about.md
+++ b/content/about.md
@@ -43,7 +43,7 @@ Writing this made me hungry... 🤤😅
 * [Sci-Fi](https://open.spotify.com/playlist/2KMP2mCrKF0MTG7QPLFJA6) 🚀
 * [Hyper-Pop](https://open.spotify.com/playlist/51GQ3RJTejomooBzBHvLJN) 🤯
 
-You can see the rest of my playlists [here](https://open.spotify.com/user/orl1r6ro371sob7h4jvk06sse/playlists) 🎧
+You can see the rest of my playlists on [my Spotify playlists page](https://open.spotify.com/user/orl1r6ro371sob7h4jvk06sse/playlists) 🎧
 
 ## Say hi
 

--- a/content/about.md
+++ b/content/about.md
@@ -1,7 +1,7 @@
 ---
 title: "About Me"
 hideTitle: false
-description: "A little bit about me"
+description: "About Pablo González: backend-focused computer engineer, current work, interests, and links to resume and contact."
 author: "Pablo Jesús González Rubio"
 imgPath: "."
 disableTitleSeparator: false

--- a/content/now.md
+++ b/content/now.md
@@ -1,7 +1,7 @@
 ---
 title: "Now"
 hideTitle: false
-description: "Things I'm focused on at this point of my life"
+description: "What Pablo González is focused on right now: work, projects, learning, and personal updates."
 author: "Pablo Jesús González Rubio"
 imgPath: "."
 disableTitleSeparator: false

--- a/content/posts/Bash_Cheatsheet/index.md
+++ b/content/posts/Bash_Cheatsheet/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Bash Scripting Cheatsheet"
-description: "A rapid guide to look at when doing some scripts as it may help when forgetting something."
+description: "Bash scripting cheatsheet with common syntax, conditionals, loops, functions, and command-line patterns for quick shell automation tasks."
 date: 2019-10-22
 lastmod: 2020-08-06T00:50:52+02:00
 author: "Pablo Jesús González Rubio"

--- a/content/posts/Data_Exfiltration/index.md
+++ b/content/posts/Data_Exfiltration/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Data Exfiltration"
-description: "In the infiltration process, attackers often need to download and execute code through commands that helps them: Collect information, Extract credentials and data, Create persistence, Privilege Escalation and lateral movement, Bypass defense methods..."
+description: "Data exfiltration techniques and command patterns used in post-exploitation to collect files, credentials, and sensitive host information."
 date: 2020-09-03
 lastmod: 2020-09-03
 author: "Pablo Jesús González Rubio"

--- a/content/posts/Pentest_Cheatsheet/index.md
+++ b/content/posts/Pentest_Cheatsheet/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Pentest Cheatsheet"
-description: "Some techniques that could be useful during a pentest, such as TTY Reverse Shell, bypassing restricted shells, path and library hijacking..."
+description: "Pentest cheatsheet with practical post-exploitation and privilege-escalation techniques, including TTY upgrades, shell escapes, and Linux escalation paths."
 date: 2019-10-11T14:22:41+02:00
 lastmod: 2020-08-06T00:50:52+02:00
 author: "Pablo Jesús González Rubio"
@@ -12,7 +12,7 @@ tags: [ "Cheatsheet" ]
 
 This post is more like some techniques that could be useful.
 
-For a guide to pentest each port click [here!](/posts/port_cheatsheet).
+For a per-port pentesting reference, see the [Port Pentesting Cheatsheet](/posts/port_cheatsheet).
 
 ## TTY Reverse Shell
 

--- a/content/posts/Port_Cheatsheet/index.md
+++ b/content/posts/Port_Cheatsheet/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Port Cheatsheet"
-description: "How to investigate and pentest most common ports"
+description: "Port pentesting cheatsheet for common services, with quick enumeration and exploitation tips for FTP, SSH, web, SMB, DNS, and database targets."
 date: 2019-10-09
 lastmod: 2020-09-12
 author: "Pablo Jesús González Rubio"

--- a/content/posts/Rfid_125/index.md
+++ b/content/posts/Rfid_125/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Low Frequency (125 KHz)"
-description: "RFID is seen today in many scenarios: the bus card, the sub ticket, gym access, access cards, payments via NFC… In this post we’ll talk only about one of the most common ones: 125 KHz"
+description: "Introduction to 125 KHz low-frequency RFID basics, attack surface, and practical cloning/testing notes for common access-control tags."
 date: 2020-06-28
 lastmod: 2020-08-06T00:50:52+02:00
 author: "Pablo Jesús González Rubio"

--- a/content/posts/Rfid_1356/index.md
+++ b/content/posts/Rfid_1356/index.md
@@ -1,6 +1,6 @@
 ---
 title: "High Frequency (13.56 MHz)"
-description: "RFID is seen today in many scenarios: the bus card, the sub ticket, gym access, access cards, payments via NFC… In this post we’ll talk only about one of the most common ones: 13.56 MHz"
+description: "Practical 13.56 MHz RFID overview covering common card technologies, attack surface, and cloning/testing techniques for NFC access systems."
 date: 2020-06-28
 lastmod: 2020-08-06T01:33:10+02:00
 author: "Pablo Jesús González Rubio"

--- a/content/posts/RogueAP/index.md
+++ b/content/posts/RogueAP/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Rogue AP"
-description: "A Rogue AP or Rogue Access Point is a hostspot that simulates a network like if it was a router, but instead it replicates the signal of an existing one and performs sniffing and Man In The Middle on every user that connects to that AP."
+description: "Rogue Access Point walkthrough covering fake hotspot setup, credential-capture flow, and practical wireless MITM testing considerations."
 date: 2019-11-24
 lastmod: 2020-08-06T00:50:52+02:00
 author: "Pablo Jesús González Rubio"

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -1,6 +1,6 @@
 +++
 aliases = ["posts", "Posts", "articles", "Articles"]
 title = "Posts"
-description = "List of posts: Cheatsheets, Guides, Projects..."
+description = "Technical blog posts about backend engineering, Python, Linux, and practical security with guides and cheatsheets."
 author = "Pablo Jesús González Rubio"
 +++

--- a/content/posts/apache/index.md
+++ b/content/posts/apache/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Apache Web Server"
-description: ""
+description: "Practical Apache web server guide covering installation, core configuration, virtual hosts, TLS basics, and hardening on Linux."
 date: 2021-05-16
 lastmod: 2021-05-16
 author: "Pablo Jesús González Rubio"

--- a/content/posts/bash_aliases/index.md
+++ b/content/posts/bash_aliases/index.md
@@ -1,6 +1,6 @@
 ---
 title: "My Bash Aliases"
-description: "Lots of useful Bash alises I've done along my Linux journey."
+description: "Curated Bash aliases to speed up daily Linux workflows, reduce repetitive commands, and improve terminal productivity."
 date: 2020-10-12
 lastmod: 2020-10-12
 author: "Pablo Jesús González Rubio"

--- a/content/posts/crypto_notes/index.md
+++ b/content/posts/crypto_notes/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Cryptocurrency notes"
-description: "My personal notes on Cryptocurrencies."
+description: "Beginner-friendly cryptocurrency notes covering risk management, strategy basics, and practical lessons learned."
 date: 2021-11-22
 lastmod: 2021-11-22T11:11:52+02:00
 author: "Pablo Jesús González Rubio"

--- a/content/posts/emailserver/index.md
+++ b/content/posts/emailserver/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Email Server - Postfix, Dovecot and Roundcube"
-description: ""
+description: "Step-by-step Linux email server setup with Postfix, Dovecot, and Roundcube, including installation, configuration, and security basics."
 date: 2021-05-21
 lastmod: 2021-05-21
 author: "Pablo Jesús González Rubio"

--- a/content/posts/linux_filesystem/index.md
+++ b/content/posts/linux_filesystem/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Linux - Filesystem"
-description: ""
+description: "Linux filesystem fundamentals: inodes, directory hierarchy, partitions, and essential commands for navigating and managing storage."
 date: 2021-04-07
 lastmod: 2021-04-07
 author: "Pablo Jesús González Rubio"

--- a/content/posts/m3u8/index.md
+++ b/content/posts/m3u8/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Download videos and streams via m3u8"
-description: "How to download videos and streams via m3u8 chunklists with VLC."
+description: "Guide to downloading video streams from m3u8 playlists using VLC and command-line methods, with troubleshooting for segmented media."
 date: 2020-10-09
 lastmod: 2020-10-10
 author: "Pablo Jesús González Rubio"

--- a/content/posts/markdown/index.md
+++ b/content/posts/markdown/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Markdown Cheatsheet"
-description: "How to easily write beautiful formatted text with Markdown."
+description: "Markdown cheatsheet with practical syntax examples for headings, links, tables, code blocks, and everyday technical writing workflows."
 date: 2020-10-11
 lastmod: 2020-10-11
 author: "Pablo Jesús González Rubio"
@@ -13,7 +13,7 @@ tags: ["Cheatsheet"]
 
 ## Introduction
 
-You can download the cheatsheet as a pdf from [here](./markdown.pdf)!
+You can download the [Markdown cheatsheet PDF](./markdown.pdf).
 
 Writing a Word document sometimes might be a bit boring and tough as you have to select the text to be **bold**, _cursive_, or to create a bulleted/numbered list and such. With Markdown everything is reduced to a simple text file such as the typical `txt` file, but formatted. One example is the above one, which is this exact page!
 

--- a/content/resume.md
+++ b/content/resume.md
@@ -1,7 +1,7 @@
 ---
 title: "Resume"
 hideTitle: false
-description: "Pablo Jesús González Rubio's Resume"
+description: "Resume of Pablo González, backend engineer with experience in Python, APIs, system architecture, and software delivery."
 author: "Pablo Jesús González Rubio"
 imgPath: "."
 disableTitleSeparator: false

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -97,21 +97,22 @@
 <meta name="description" content="{{ . }}">{{ end }}
 
 
-<meta name="robots" content="{{ if and (ne .Kind " 404") (ne .Params.noindex true) }}index follow{{ else }}noindex
-  follow{{ end }}">
+<meta name="robots" content="{{ if and (ne .Kind "404") (ne .Params.noindex true) }}index follow{{ else }}noindex follow{{ end }}">
 <meta name="referrer" content="no-referrer-when-downgrade">
 
 
 <!-- Canon -->
-{{ if and (.IsPage) (not .Params.sitemapExclude) }}
+{{ if ne .Kind "404" }}
 {{ if .Params.canonicalURL }}
 <link rel="canonical" href="{{ .Params.canonicalURL }}">
-{{ else if and (ne .Kind "404") (ne .Params.sitemapExclude true) }}
+{{ else if and (eq .Kind "section") (gt .Paginator.TotalPages 0) }}
+<link rel="canonical" href="{{ .Paginator.URL | absURL }}">
+{{ else if ne .Params.sitemapExclude true }}
 <link rel="canonical" href="{{ .Permalink }}">
 {{ end }}
-{{ else if (eq .Kind "section") }}
-<link rel="canonical" href="{{ .Paginator.URL | absURL }}">
+{{ end }}
 
+{{ if (eq .Kind "section") }}
 {{ if .Paginator.HasPrev }}
 <link rel="prev" href="{{ .Paginator.Prev.URL | absURL }}">
 {{ end }}
@@ -133,6 +134,9 @@
 <meta property="og:title" content="{{ $currentTitle }}">
 {{ with $currentDesc }}
 <meta property="og:description" content="{{ . }}">{{ end }}
+<meta name="twitter:title" content="{{ $currentTitle }}">
+{{ with $currentDesc }}
+<meta name="twitter:description" content="{{ . }}">{{ end }}
 
 {{- if ne .Kind "404" }}
 <meta property="og:url" content="{{ .Permalink }}">
@@ -228,10 +232,9 @@ $highRes 0)).Permalink)) }}
 
 <!-- PWA Manifest -->
 <link rel="manifest" href="/manifest.json">
-<link rel="manifest" href="manifest.json" />
 
 <!-- Feed -->
-<link rel="alternate" type="application/rss+xml" href="{{ " index.xml" | relURL }}" title="{{ .Site.Title }}">
+<link rel="alternate" type="application/rss+xml" href="{{ "index.xml" | relURL }}" title="{{ .Site.Title }}">
 
 <!-- i18n -->
 {{ if .IsTranslated }}
@@ -300,8 +303,8 @@ $highRes 0)).Permalink)) }}
       "@context": "https://schema.org",
       "@type": "Article",
       "mainEntityOfPage": {
-        "@type": "WebSite",
-        "@id": "{{ .Site.BaseURL }}"
+        "@type": "WebPage",
+        "@id": "{{ .Permalink }}"
       },
       "headline": {{ $currentTitle }},
       "description": {{ $currentDesc }},
@@ -332,7 +335,10 @@ $highRes 0)).Permalink)) }}
       "inLanguage": "{{ .Site.Language.Lang }}",
       "name": {{ .Site.Title }},
       "description": {{ .Site.Params.description | emojify }},
-      "publisher": "{{ .Site.Params.author }}"
+      "publisher": {
+        "@type": "Person",
+        "name": "{{ .Site.Params.author }}"
+      }
     }
   </script>
 {{ end }}


### PR DESCRIPTION
## Summary
- harden site-level SEO metadata generation (robots, canonical, RSS link, social tags, and structured data output)
- improve homepage/section page descriptions and tighten legacy post descriptions for stronger SERP snippets
- replace vague anchor labels with clearer descriptive link text in key pages

## Test plan
- [x] Run `hugo --gc --minify`
- [x] Spot-check generated metadata in home, post, tag, and 404 pages
- [x] Verify robots and sitemap generation