### PR TITLE
Improve homepage SEO signals and owner SEO docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,7 @@ Before finalizing work:
 - Main config: `config.toml`
 - CI workflow: `.github/workflows/hugo.yml`
 - Scripts: `deploy.sh`, `editBlog.sh`
+
+## Deployment Note
+
+- Typical Cloudflare deployment time is about 2 minutes.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,26 @@
+# SEO Tasks (Owner)
+
+## Platform and Domain
+
+- [ ] Choose one canonical host: `https://pablogonzalez.me` or `https://www.pablogonzalez.me`.
+- [ ] Add a Cloudflare redirect rule (301) from the non-canonical host to the canonical host.
+- [ ] Verify both `http` and `https` variants resolve to the same canonical URL.
+- [ ] Enable HSTS in Cloudflare with a safe rollout (short max-age first, then increase).
+
+## Search Console and Indexing
+
+- [x] Add and verify site property in Google Search Console.
+- [ ] Verify the canonical property in Google Search Console.
+- [ ] Re-submit sitemap after canonical redirect changes.
+- [ ] Monitor indexing/canonical reports for 1-2 weeks and resolve any mismatches.
+
+## Ads.txt Decision
+
+- [x] Decide ads policy: no ads will be served on this site.
+- [ ] Publish a minimal `ads.txt` statement reflecting the no-ads policy.
+
+## Authority and Backlinks
+
+- [ ] Improve referring domains with high-quality links (guest posts, relevant profiles, project references).
+- [ ] Prioritize links from unique domains/IP ranges instead of repeated links from the same source.
+- [ ] Track backlink growth monthly (referring domains, backlinks, and linking root IPs).

--- a/config.toml
+++ b/config.toml
@@ -30,7 +30,7 @@ noClasses = false
 # GA4 = "G-GWC49NSYGC" # Google Analytics 4
 
 # Site description
-description = "Hi there! I'm Pablo Jesús González Rubio, a Python Engineer and Web Developer based in Salamanca, Spain."
+description = "Backend development, Linux, and cybersecurity posts by Pablo González. Practical guides, cheatsheets, and project notes for developers and security learners."
 
 # Author
 author = "Pablo Jesús González Rubio"

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,7 @@
 ---
-title: "Home"
-hideTitle: true
+title: "Pablo Gonzalez - Backend Developer"
+hideTitle: false
+mainTitle: "Backend Development, Linux, and Security Posts"
 description: "Personal website of Pablo González, Python backend engineer sharing software development guides, Linux notes, and cybersecurity writeups."
 author: "Pablo Jesús González Rubio"
 imgPath: "."
@@ -11,27 +12,29 @@ coverAlt: "Pablo González Image"
 
 {{< imgRounded "me.webp" "Photo of Pablo" "borderless" "400" >}}
 
-<span style="font-size:3em; font-weight:500">👋 Hello, I'm **Pablo González**</span>
+I'm a Computer Engineer focused on backend development with Python. I enjoy building API-first services, improving software architecture, and keeping codebases maintainable with practical clean code habits.
 
-I'm a Computer Engineer passionate about backend development in Python 🐍 and a Clean Code advocate 🥑. As a developer, I specialize in OOP (mainly with DDD), system architecture, developing API-First systems (primarily with FastAPI), and leading backend projects from start to finish 💻🚀.
+This website is my technical space where I publish posts and notes about software development, Linux administration, and security topics that I use in real projects and hands-on labs. I write in a practical format so I can revisit each guide quickly, and so other developers can apply the same ideas without too much setup.
 
-If you would like to know more about me, feel free to explore the following sections:
+If you want a quick overview of my background, current focus, and tools, start here:
 
 * 🙍🏻‍♂️ [About Me](/about)
 * 📄 [Resume](/resume)
 * ⏳ [Now](/now)
 * 🛠️ [What I Use](/uses)
 
-I know that you may not be interested in viewing the analytics of this site, but if you are, [they are public!](https://cloud.umami.is/share/sMn2hgzqZZ0lEpde/pablogonzalez.me)
+## Posts and Development Topics
 
-You might also like to visit my [blog](/posts) 📝, where I talk about:
+You can also browse the [blog](/posts) 📝 by topic:
 
-* [Software Development](tags/software-development/): Development guides and approaches 💻
-* [Cheatsheets](tags/cheatsheet/): Helpful tips I've gathered 📋
-* [Linux Posts](tags/linux/): Learn and use Linux with ease 🐧
-* [Hack The Box Writeups](writeups/htb/): Cybersecurity challenges I've tackled in the past 🔒
+* [Software Development](tags/software-development/): backend engineering practices, architecture decisions, and coding workflows.
+* [Cheatsheets](tags/cheatsheet/): concise command references and troubleshooting shortcuts.
+* [Linux Posts](tags/linux/): system administration notes, hardening basics, and server operations.
+* [Hack The Box Writeups](writeups/htb/): security challenge writeups and exploitation walkthroughs.
 
-Hope you find something useful or interesting, and I'm always here if you want to get in touch! 😊
+If you are curious about traffic, [public site analytics are available](https://cloud.umami.is/share/sMn2hgzqZZ0lEpde/pablogonzalez.me).
+
+I update this site whenever I discover a better approach, fix an old process, or learn something worth documenting. If a post helps you, feel free to reach out and share improvements or corrections.
 
 ## Contact
 

--- a/docs/project-guide.md
+++ b/docs/project-guide.md
@@ -95,6 +95,12 @@ n0nuser.github.io/
 
 - Primary operational target: Cloudflare Pages
 - GitHub Pages workflow has been removed/deactivated to avoid parallel deployment paths
+- Typical Cloudflare deployment time is about 2 minutes
+
+### SEO and Search Operations
+
+- Google Search Console property has been added for this site.
+- Ads policy: no ads are served on this site; keep `ads.txt` aligned with this policy if published.
 
 ### Existing Automation and Scripts
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -104,7 +104,7 @@
 <!-- Canon -->
 {{ if ne .Kind "404" }}
 {{ if .Params.canonicalURL }}
-<link rel="canonical" href="{{ .Params.canonicalURL }}">
+<link rel="canonical" href="{{ .Params.canonicalURL | absURL }}">
 {{ else if and (eq .Kind "section") (gt .Paginator.TotalPages 0) }}
 <link rel="canonical" href="{{ .Paginator.URL | absURL }}">
 {{ else if ne .Params.sitemapExclude true }}

--- a/layouts/partials/myscripts.html
+++ b/layouts/partials/myscripts.html
@@ -8,4 +8,6 @@
 <meta name="application-name" content="&nbsp;" />
 
 <!-- Umami Analytics -->
+<link rel="preconnect" href="https://cloud.umami.is" crossorigin>
+<link rel="dns-prefetch" href="//cloud.umami.is">
 <script defer src="https://cloud.umami.is/script.js" data-website-id="a22e739e-a7c7-4a51-85a9-0b544d2906aa"></script>


### PR DESCRIPTION
## Summary
- improve homepage SEO signals with stronger title, heading, and expanded content depth
- add canonical robustness and small external script connection hints in head partials
- document owner-side SEO operations in `TASKS.md`, plus Search Console and no-ads policy notes in project docs

## Test plan
- [x] Run `hugo --gc --minify`
- [x] Verify homepage metadata and heading output
- [x] Confirm canonical tag generation remains consistent