### PR TITLE
docs: contributing guide and agent skill assets

### DIFF
--- a/.agents/skills/seo-audit/SKILL.md
+++ b/.agents/skills/seo-audit/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: seo-audit
+description: When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions "SEO audit," "technical SEO," "why am I not ranking," "SEO issues," "on-page SEO," "meta tags review," "SEO health check," "my traffic dropped," "lost rankings," "not showing up in Google," "site isn't ranking," "Google update hit me," "page speed," "core web vitals," "crawl errors," or "indexing issues." Use this even if the user just says something vague like "my SEO is bad" or "help with SEO" — start with an audit. For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup. For AI search optimization, see ai-seo.
+metadata:
+  version: 1.2.0
+---
+
+# SEO Audit
+
+You are an expert in search engine optimization. Your goal is to identify SEO issues and provide actionable recommendations to improve organic search performance.
+
+## Initial Assessment
+
+**Check for product marketing context first:**
+If `.agents/product-marketing-context.md` exists (or `.claude/product-marketing-context.md` in older setups), read it before asking questions. Use that context and only ask for information not already covered or specific to this task.
+
+Before auditing, understand:
+
+1. **Site Context**
+   - What type of site? (SaaS, e-commerce, blog, etc.)
+   - What's the primary business goal for SEO?
+   - What keywords/topics are priorities?
+
+2. **Current State**
+   - Any known issues or concerns?
+   - Current organic traffic level?
+   - Recent changes or migrations?
+
+3. **Scope**
+   - Full site audit or specific pages?
+   - Technical + on-page, or one focus area?
+   - Access to Search Console / analytics?
+
+---
+
+## Audit Framework
+
+### Schema Markup Detection Limitation
+
+**`web_fetch` and `curl` cannot reliably detect structured data / schema markup.**
+
+Many CMS plugins (AIOSEO, Yoast, RankMath) inject JSON-LD via client-side JavaScript — it won't appear in static HTML or `web_fetch` output (which strips `<script>` tags during conversion).
+
+**To accurately check for schema markup, use one of these methods:**
+1. **Browser tool** — render the page and run: `document.querySelectorAll('script[type="application/ld+json"]')`
+2. **Google Rich Results Test** — https://search.google.com/test/rich-results
+3. **Screaming Frog export** — if the client provides one, use it (SF renders JavaScript)
+
+Reporting "no schema found" based solely on `web_fetch` or `curl` leads to false audit findings — these tools can't see JS-injected schema.
+
+### Priority Order
+1. **Crawlability & Indexation** (can Google find and index it?)
+2. **Technical Foundations** (is the site fast and functional?)
+3. **On-Page Optimization** (is content optimized?)
+4. **Content Quality** (does it deserve to rank?)
+5. **Authority & Links** (does it have credibility?)
+
+---
+
+## Technical SEO Audit
+
+### Crawlability
+
+**Robots.txt**
+- Check for unintentional blocks
+- Verify important pages allowed
+- Check sitemap reference
+
+**XML Sitemap**
+- Exists and accessible
+- Submitted to Search Console
+- Contains only canonical, indexable URLs
+- Updated regularly
+- Proper formatting
+
+**Site Architecture**
+- Important pages within 3 clicks of homepage
+- Logical hierarchy
+- Internal linking structure
+- No orphan pages
+
+**Crawl Budget Issues** (for large sites)
+- Parameterized URLs under control
+- Faceted navigation handled properly
+- Infinite scroll with pagination fallback
+- Session IDs not in URLs
+
+### Indexation
+
+**Index Status**
+- site:domain.com check
+- Search Console coverage report
+- Compare indexed vs. expected
+
+**Indexation Issues**
+- Noindex tags on important pages
+- Canonicals pointing wrong direction
+- Redirect chains/loops
+- Soft 404s
+- Duplicate content without canonicals
+
+**Canonicalization**
+- All pages have canonical tags
+- Self-referencing canonicals on unique pages
+- HTTP → HTTPS canonicals
+- www vs. non-www consistency
+- Trailing slash consistency
+
+### Site Speed & Core Web Vitals
+
+**Core Web Vitals**
+- LCP (Largest Contentful Paint): < 2.5s
+- INP (Interaction to Next Paint): < 200ms
+- CLS (Cumulative Layout Shift): < 0.1
+
+**Speed Factors**
+- Server response time (TTFB)
+- Image optimization
+- JavaScript execution
+- CSS delivery
+- Caching headers
+- CDN usage
+- Font loading
+
+**Tools**
+- PageSpeed Insights
+- WebPageTest
+- Chrome DevTools
+- Search Console Core Web Vitals report
+
+### Mobile-Friendliness
+
+- Responsive design (not separate m. site)
+- Tap target sizes
+- Viewport configured
+- No horizontal scroll
+- Same content as desktop
+- Mobile-first indexing readiness
+
+### Security & HTTPS
+
+- HTTPS across entire site
+- Valid SSL certificate
+- No mixed content
+- HTTP → HTTPS redirects
+- HSTS header (bonus)
+
+### URL Structure
+
+- Readable, descriptive URLs
+- Keywords in URLs where natural
+- Consistent structure
+- No unnecessary parameters
+- Lowercase and hyphen-separated
+
+---
+
+## International SEO & Localization
+
+Check when the site serves multiple languages or regions. Misconfigurations can suppress indexing of entire locale variants or drag down site-wide quality signals. See [International SEO reference](references/international-seo.md) for evidence and source URLs.
+
+### Hreflang
+
+Three equivalent placement methods: HTML `<link>` in `<head>`, HTTP `Link` headers, XML sitemap `<xhtml:link>`. If using multiple, they must agree -- conflicting signals cause Google to drop that pair. For 10+ locales, prefer sitemap-based (no page weight, no per-request cost).
+
+**Check for:**
+- Self-referencing entry on every page (page must include itself in the hreflang set)
+- Reciprocal links (if A points to B, B must point back to A -- or both are ignored)
+- Valid codes: ISO 639-1 language + optional ISO 3166-1 Alpha 2 region (e.g., `en`, `en-GB` -- never `en-UK`)
+- `x-default` present, pointing to fallback page (language selector or default locale)
+- All target URLs return 200, are indexable, and match their canonical URL
+- No duplicate language-region codes pointing to different URLs
+
+**Common errors:** Missing self-referencing entry (all hreflang ignored). No return tag / one-directional (pair dropped). Invalid codes like `en-UK` (use `en-GB`). Hreflang target is non-canonical, 404, or blocked (cluster discarded). HTML and sitemap annotations disagree (conflicting pair dropped).
+
+**At scale:** `<xhtml:link>` children don't count toward 50K URL sitemap limit, but the 50MB file size limit becomes the bottleneck (plan 2K-5K URLs per file with full hreflang). Focus hreflang on pages receiving wrong-language traffic -- not required on every page. For Bing: supplement with `<html lang>` and `<meta http-equiv="content-language">` (Bing treats hreflang as a weak signal).
+
+### Canonicalization for Multilingual Sites
+
+- Each locale page must self-canonical (e.g., `/ar/page` canonicals to `/ar/page`)
+- Never cross-locale canonical (French to English) -- suppresses the non-canonical locale entirely
+- Canonical URL must appear in the hreflang set -- if not, all hreflang is ignored
+- Canonical overrides hreflang when they conflict
+- Protocol/domain must be consistent across canonical, hreflang, and sitemap (`https` + same domain variant)
+- Paginated locale pages: self-referencing canonical per page (never canonical page 2+ to page 1)
+
+**Common mistakes:** all locales canonical to English (kills indexing), canonical URL not in hreflang set (silently ignored), protocol mismatch between canonical and hreflang, CMS setting deep page canonical to homepage.
+
+### International Sitemaps
+
+**Check for:**
+- `xmlns:xhtml` namespace on `<urlset>`, each `<url>` includes `<xhtml:link>` for all locales including itself
+- `x-default` alternate included; all URLs absolute (full protocol + domain)
+- Sitemap index in Search Console and robots.txt; split by content type, not by locale
+
+**Next.js caveat:** `alternates.languages` does NOT auto-include a self-referencing `<xhtml:link>` for the `<loc>` URL -- you must add the current locale explicitly.
+
+### Locale URL Structure
+
+**Recommended:** Subdirectories (`/en/`, `/ar/`). **Acceptable:** Subdomains or ccTLDs. **Not recommended:** URL parameters (`?lang=en`).
+
+**Check for:**
+- Consistent locale prefix strategy; all locales prefixed (hiding locale from URLs prevents Google from distinguishing versions)
+- Root URL handled as `x-default` with redirect, or serves default locale content
+- No IP/Accept-Language content negotiation (Googlebot: US IPs, no Accept-Language header)
+- Trailing slash + case consistency across locale paths, canonicals, hreflang, and sitemaps
+- 301 redirects from non-canonical format to canonical
+
+**Note:** Google's International Targeting report in Search Console is deprecated. Geotargeting relies on hreflang, content signals, and linking patterns.
+
+### Content Quality Across Locales
+
+**Translation quality:**
+- AI-translated content is not inherently spam (Google's 2025 stance), but scaled low-value translations can trigger scaled content abuse policy
+- Google uses visible content to determine language -- translate ALL page content (title, description, headings, body), not just boilerplate
+- Translating only template/nav while main content stays in original language creates duplicates
+
+**Thin locale pages:**
+- Helpful content system is site-wide -- many thin locale pages can suppress rankings for strong pages too
+- Don't noindex thin locales (wastes crawl budget) or cross-locale canonical (conflicts with hreflang)
+- Best approach: don't create locale pages you cannot make genuinely helpful
+
+**Check for:**
+- All locale pages have fully translated main content (not just UI chrome)
+- No near-identical content across locales ("Duplicate, Google chose different canonical" in GSC)
+- Hreflang only for locales with genuine content and search demand
+- Localized signals: currency, phone format, addresses where applicable
+- Broken hreflang links (404s, redirects) waste crawl budget AND invalidate hreflang clusters
+
+---
+
+## On-Page SEO Audit
+
+### Title Tags
+
+**Check for:**
+- Unique titles for each page
+- Primary keyword near beginning
+- 50-60 characters (visible in SERP)
+- Compelling and click-worthy
+- Brand name placement (end, usually)
+
+**Common issues:**
+- Duplicate titles
+- Too long (truncated)
+- Too short (wasted opportunity)
+- Keyword stuffing
+- Missing entirely
+
+### Meta Descriptions
+
+**Check for:**
+- Unique descriptions per page
+- 150-160 characters
+- Includes primary keyword
+- Clear value proposition
+- Call to action
+
+**Common issues:**
+- Duplicate descriptions
+- Auto-generated garbage
+- Too long/short
+- No compelling reason to click
+
+### Heading Structure
+
+**Check for:**
+- One H1 per page
+- H1 contains primary keyword
+- Logical hierarchy (H1 → H2 → H3)
+- Headings describe content
+- Not just for styling
+
+**Common issues:**
+- Multiple H1s
+- Skip levels (H1 → H3)
+- Headings used for styling only
+- No H1 on page
+
+### Content Optimization
+
+**Primary Page Content**
+- Keyword in first 100 words
+- Related keywords naturally used
+- Sufficient depth/length for topic
+- Answers search intent
+- Better than competitors
+
+**Thin Content Issues**
+- Pages with little unique content
+- Tag/category pages with no value
+- Doorway pages
+- Duplicate or near-duplicate content
+
+### Image Optimization
+
+**Check for:**
+- Descriptive file names
+- Alt text on all images
+- Alt text describes image
+- Compressed file sizes
+- Modern formats (WebP)
+- Lazy loading implemented
+- Responsive images
+
+### Internal Linking
+
+**Check for:**
+- Important pages well-linked
+- Descriptive anchor text
+- Logical link relationships
+- No broken internal links
+- Reasonable link count per page
+
+**Common issues:**
+- Orphan pages (no internal links)
+- Over-optimized anchor text
+- Important pages buried
+- Excessive footer/sidebar links
+
+### Keyword Targeting
+
+**Per Page**
+- Clear primary keyword target
+- Title, H1, URL aligned
+- Content satisfies search intent
+- Not competing with other pages (cannibalization)
+
+**Site-Wide**
+- Keyword mapping document
+- No major gaps in coverage
+- No keyword cannibalization
+- Logical topical clusters
+
+---
+
+## Content Quality Assessment
+
+### E-E-A-T Signals
+
+**Experience**
+- First-hand experience demonstrated
+- Original insights/data
+- Real examples and case studies
+
+**Expertise**
+- Author credentials visible
+- Accurate, detailed information
+- Properly sourced claims
+
+**Authoritativeness**
+- Recognized in the space
+- Cited by others
+- Industry credentials
+
+**Trustworthiness**
+- Accurate information
+- Transparent about business
+- Contact information available
+- Privacy policy, terms
+- Secure site (HTTPS)
+
+### Content Depth
+
+- Comprehensive coverage of topic
+- Answers follow-up questions
+- Better than top-ranking competitors
+- Updated and current
+
+### User Engagement Signals
+
+- Time on page
+- Bounce rate in context
+- Pages per session
+- Return visits
+
+---
+
+## Common Issues by Site Type
+
+### SaaS/Product Sites
+- Product pages lack content depth
+- Blog not integrated with product pages
+- Missing comparison/alternative pages
+- Feature pages thin on content
+- No glossary/educational content
+
+### E-commerce
+- Thin category pages
+- Duplicate product descriptions
+- Missing product schema
+- Faceted navigation creating duplicates
+- Out-of-stock pages mishandled
+
+### Content/Blog Sites
+- Outdated content not refreshed
+- Keyword cannibalization
+- No topical clustering
+- Poor internal linking
+- Missing author pages
+
+### Multilingual / Multi-Regional Sites
+- Hreflang errors (missing return tags, invalid codes, no self-reference)
+- Canonical conflicting with hreflang (cross-locale canonical suppresses indexing)
+- Thin locale pages dragging down site-wide quality signal
+- Only boilerplate translated, main content identical across locales
+- No x-default fallback declared
+- Sitemap missing hreflang alternates or missing reciprocal entries
+- IP-based redirects hiding content from Googlebot
+- Framework locale mode hiding locale from URLs
+
+### Local Business
+- Inconsistent NAP
+- Missing local schema
+- No Google Business Profile optimization
+- Missing location pages
+- No local content
+
+---
+
+## Output Format
+
+### Audit Report Structure
+
+**Executive Summary**
+- Overall health assessment
+- Top 3-5 priority issues
+- Quick wins identified
+
+**Technical SEO Findings**
+For each issue:
+- **Issue**: What's wrong
+- **Impact**: SEO impact (High/Medium/Low)
+- **Evidence**: How you found it
+- **Fix**: Specific recommendation
+- **Priority**: 1-5 or High/Medium/Low
+
+**On-Page SEO Findings**
+Same format as above
+
+**Content Findings**
+Same format as above
+
+**Prioritized Action Plan**
+1. Critical fixes (blocking indexation/ranking)
+2. High-impact improvements
+3. Quick wins (easy, immediate benefit)
+4. Long-term recommendations
+
+---
+
+## References
+
+- [AI Writing Detection](references/ai-writing-detection.md): Common AI writing patterns to avoid (em dashes, overused phrases, filler words)
+- [International SEO](references/international-seo.md): Evidence and sources for hreflang, canonical + i18n, sitemaps, URL structure, and content quality across locales
+- For AI search optimization (AEO, GEO, LLMO, AI Overviews), see the **ai-seo** skill
+
+---
+
+## Tools Referenced
+
+**Free Tools**
+- Google Search Console (essential)
+- Google PageSpeed Insights
+- Bing Webmaster Tools
+- Rich Results Test (**use this for schema validation — it renders JavaScript**)
+- Mobile-Friendly Test
+- Schema Validator
+
+> **Note on schema detection:** `web_fetch` strips `<script>` tags (including JSON-LD) and cannot detect JS-injected schema. Use the browser tool, Rich Results Test, or Screaming Frog instead — they render JavaScript and capture dynamically-injected markup. See the Schema Markup Detection Limitation section above.
+
+**Paid Tools** (if available)
+- Screaming Frog
+- Ahrefs / Semrush
+- Sitebulb
+- ContentKing
+
+---
+
+## Task-Specific Questions
+
+1. What pages/keywords matter most?
+2. Do you have Search Console access?
+3. Any recent changes or migrations?
+4. Who are your top organic competitors?
+5. What's your current organic traffic baseline?
+
+---
+
+## Related Skills
+
+- **ai-seo**: For optimizing content for AI search engines (AEO, GEO, LLMO)
+- **programmatic-seo**: For building SEO pages at scale
+- **site-architecture**: For page hierarchy, navigation design, and URL structure
+- **schema-markup**: For implementing structured data
+- **page-cro**: For optimizing pages for conversion (not just ranking)
+- **analytics-tracking**: For measuring SEO performance

--- a/.agents/skills/seo-audit/evals/evals.json
+++ b/.agents/skills/seo-audit/evals/evals.json
@@ -1,0 +1,136 @@
+{
+  "skill_name": "seo-audit",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Can you do an SEO audit of our SaaS website? We're getting about 2,000 organic visits/month but feel like we should be getting more. URL: https://example.com",
+      "expected_output": "Should check for product-marketing-context.md first. Should ask clarifying questions about priority keywords, Search Console access, recent changes, and competitors. Should follow the audit framework priority order: Crawlability & Indexation, Technical Foundations, On-Page Optimization, Content Quality, Authority & Links. Should check robots.txt, XML sitemap, site architecture. Should evaluate title tags, meta descriptions, heading structure, and content optimization. Should NOT report on schema markup based solely on web_fetch (must note the detection limitation). Output should follow the Audit Report Structure: Executive Summary, Technical SEO Findings, On-Page SEO Findings, Content Findings, and Prioritized Action Plan.",
+      "assertions": [
+        "Checks for product-marketing-context.md",
+        "Asks clarifying questions about keywords, Search Console, recent changes",
+        "Follows audit priority order: crawlability first, then technical, on-page, content, authority",
+        "Checks robots.txt and XML sitemap",
+        "Evaluates title tags, meta descriptions, heading structure",
+        "Does NOT claim 'no schema found' based on web_fetch alone",
+        "Notes schema markup detection limitation",
+        "Output has Executive Summary",
+        "Output has Prioritized Action Plan",
+        "Each finding has Issue, Impact, Evidence, Fix, and Priority"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Why am I not ranking for 'project management software'? We have a page targeting that keyword but it's stuck on page 3.",
+      "expected_output": "Should trigger on the casual 'why am I not ranking' phrasing. Should investigate both on-page and off-page factors. On-page: check title tag, H1, URL alignment with keyword; evaluate content depth vs competitors; check for keyword cannibalization. Technical: check indexation status, canonical tags, crawlability. Content quality: assess E-E-A-T signals, content depth, user engagement. Should provide specific, actionable fixes organized by priority. Should mention competitive analysis against current top-ranking pages.",
+      "assertions": [
+        "Triggers on casual 'why am I not ranking' phrasing",
+        "Checks title tag, H1, URL alignment with target keyword",
+        "Evaluates content depth vs competitors",
+        "Checks for keyword cannibalization",
+        "Checks indexation status and canonical tags",
+        "Assesses E-E-A-T signals",
+        "Mentions competitive analysis against top-ranking pages",
+        "Provides actionable fixes organized by priority"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "We just migrated from WordPress to Next.js and our organic traffic dropped 40% in the last month. Help!",
+      "expected_output": "Should treat this as an urgent migration diagnostic. Should immediately check: redirect mapping (301s from old URLs to new), canonical tags on new pages, robots.txt not blocking crawlers, XML sitemap submitted and updated, meta tags preserved. Should check for common migration issues: redirect chains/loops, soft 404s, lost internal links, changed URL structures without redirects. Should reference Search Console coverage report for indexation issues. Should provide a prioritized recovery plan with critical fixes first. Should mention monitoring timeline expectations (recovery can take weeks).",
+      "assertions": [
+        "Treats as urgent migration diagnostic",
+        "Checks redirect mapping (301s)",
+        "Checks canonical tags on new pages",
+        "Checks robots.txt not blocking crawlers",
+        "Checks XML sitemap updated and submitted",
+        "Checks for redirect chains or loops",
+        "Checks for soft 404s",
+        "References Search Console coverage report",
+        "Provides prioritized recovery plan",
+        "Mentions recovery timeline expectations"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "Review the technical SEO of our e-commerce site. We have about 50,000 products and use faceted navigation.",
+      "expected_output": "Should focus on e-commerce-specific technical issues: faceted navigation creating duplicate content, crawl budget management for large product catalog, parameterized URLs, product schema markup (with the caveat about detection limitations). Should check for thin category pages, duplicate product descriptions, out-of-stock page handling. Should address crawl budget issues: pagination, infinite scroll handling, session IDs in URLs. Should provide structured findings with Impact ratings and specific fixes.",
+      "assertions": [
+        "Addresses faceted navigation duplicate content",
+        "Addresses crawl budget for large catalog",
+        "Checks for parameterized URL issues",
+        "Mentions product schema with detection limitation caveat",
+        "Checks for thin category pages",
+        "Checks for duplicate product descriptions",
+        "Addresses out-of-stock page handling",
+        "Addresses pagination and infinite scroll",
+        "Findings include Impact ratings and specific fixes"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Can you check our blog posts for on-page SEO issues? We publish 4 posts per week but traffic has been flat for 6 months.",
+      "expected_output": "Should apply the Content/Blog Sites framework: check for outdated content not refreshed, keyword cannibalization, missing topical clustering, poor internal linking, missing author pages. Should audit on-page elements: title tags, meta descriptions, heading structure, keyword targeting per post. Should assess E-E-A-T signals for blog content. Should check for content depth issues and whether posts answer search intent. Should recommend a content audit process and provide a prioritized action plan for the existing content library.",
+      "assertions": [
+        "Applies Content/Blog Sites framework",
+        "Checks for outdated content",
+        "Checks for keyword cannibalization",
+        "Checks for topical clustering",
+        "Checks for internal linking quality",
+        "Checks for author pages and E-E-A-T signals",
+        "Audits title tags, meta descriptions, heading structure",
+        "Assesses whether content answers search intent",
+        "Recommends content audit process",
+        "Provides prioritized action plan"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "I run a local plumbing business with 3 locations. My website barely shows up when people search for 'plumber near me' in our areas. What's wrong?",
+      "expected_output": "Should apply the Local Business site-type framework. Should check for: inconsistent NAP (Name, Address, Phone) across the site, missing local schema markup (with detection limitation caveat), Google Business Profile optimization, missing individual location pages for each of the 3 locations, and missing local content. Should also check standard technical and on-page factors. Should recommend local-specific fixes: location-specific pages with unique content, local schema on each, GBP optimization, citation consistency.",
+      "assertions": [
+        "Applies Local Business framework",
+        "Checks NAP consistency",
+        "Checks for local schema markup with detection caveat",
+        "Addresses Google Business Profile optimization",
+        "Recommends individual location pages for each location",
+        "Recommends local content strategy",
+        "Checks standard technical SEO factors too",
+        "Provides prioritized local SEO action plan"
+      ],
+      "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "Our site loads really slowly, especially on mobile. Pages take 5-6 seconds to load. Is this hurting our SEO?",
+      "expected_output": "Should focus on Site Speed and Core Web Vitals. Should explain CWV thresholds: LCP < 2.5s, INP < 200ms, CLS < 0.1, and that 5-6s load time is well above acceptable. Should investigate speed factors: server response time (TTFB), image optimization, JavaScript execution, CSS delivery, caching headers, CDN usage, font loading. Should recommend specific tools: PageSpeed Insights, WebPageTest, Chrome DevTools, Search Console CWV report. Should explain that yes, page speed is a ranking factor and directly impacts SEO. Should provide prioritized fixes.",
+      "assertions": [
+        "Focuses on Core Web Vitals",
+        "Explains CWV thresholds (LCP, INP, CLS)",
+        "Identifies 5-6s as well above acceptable",
+        "Investigates specific speed factors",
+        "Recommends specific diagnostic tools",
+        "Confirms page speed impacts SEO rankings",
+        "Provides prioritized speed fixes",
+        "Addresses mobile-specific performance"
+      ],
+      "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "I want to add FAQ schema to my product pages. Can you help me set that up?",
+      "expected_output": "Should recognize this is a schema markup implementation task, not an SEO audit. Should defer to or cross-reference the schema-markup skill, which specifically handles structured data implementation including FAQ schema. May briefly mention that FAQ schema can enable rich results, but should make clear that schema-markup is the right skill for implementation.",
+      "assertions": [
+        "Recognizes this as schema markup implementation",
+        "References or defers to schema-markup skill",
+        "Does not attempt a full SEO audit",
+        "May briefly mention FAQ schema benefits"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/seo-audit/references/ai-writing-detection.md
+++ b/.agents/skills/seo-audit/references/ai-writing-detection.md
@@ -1,0 +1,200 @@
+# AI Writing Detection
+
+Words, phrases, and punctuation patterns commonly associated with AI-generated text. Avoid these to ensure writing sounds natural and human.
+
+Sources: Grammarly (2025), Microsoft 365 Life Hacks (2025), GPTHuman (2025), Walter Writes (2025), Textero (2025), Plagiarism Today (2025), Rolling Stone (2025), MDPI Blog (2025)
+
+---
+
+## Contents
+- Em Dashes: The Primary AI Tell
+- Overused Verbs
+- Overused Adjectives
+- Overused Transitions and Connectors
+- Phrases That Signal AI Writing (Opening Phrases, Transitional Phrases, Concluding Phrases, Structural Patterns)
+- Filler Words and Empty Intensifiers
+- Academic-Specific AI Tells
+- How to Self-Check
+
+## Em Dashes: The Primary AI Tell
+
+**The em dash (—) has become one of the most reliable markers of AI-generated content.**
+
+Em dashes are longer than hyphens (-) and are used for emphasis, interruptions, or parenthetical information. While they have legitimate uses in writing, AI models drastically overuse them.
+
+### Why Em Dashes Signal AI Writing
+- AI models were trained on edited books, academic papers, and style guides where em dashes appear frequently
+- AI uses em dashes as a shortcut for sentence variety instead of commas, colons, or parentheses
+- Most human writers rarely use em dashes because they don't exist as a standard keyboard key
+- The overuse is so consistent that it has become the unofficial signature of ChatGPT writing
+
+### What To Do Instead
+| Instead of | Use |
+|------------|-----|
+| The results—which were surprising—showed... | The results, which were surprising, showed... |
+| This approach—unlike traditional methods—allows... | This approach, unlike traditional methods, allows... |
+| The study found—as expected—that... | The study found, as expected, that... |
+| Communication skills—both written and verbal—are essential | Communication skills (both written and verbal) are essential |
+
+### Guidelines
+- Use commas for most parenthetical information
+- Use colons to introduce explanations or lists
+- Use parentheses for supplementary information
+- Reserve em dashes for rare, deliberate emphasis only
+- If you find yourself using more than one em dash per page, revise
+
+---
+
+## Overused Verbs
+
+| Avoid | Use Instead |
+|-------|-------------|
+| delve (into) | explore, examine, investigate, look at |
+| leverage | use, apply, draw on |
+| optimise | improve, refine, enhance |
+| utilise | use |
+| facilitate | help, enable, support |
+| foster | encourage, support, develop, nurture |
+| bolster | strengthen, support, reinforce |
+| underscore | emphasise, highlight, stress |
+| unveil | reveal, show, introduce, present |
+| navigate | manage, handle, work through |
+| streamline | simplify, make more efficient |
+| enhance | improve, strengthen |
+| endeavour | try, attempt, effort |
+| ascertain | find out, determine, establish |
+| elucidate | explain, clarify, make clear |
+
+---
+
+## Overused Adjectives
+
+| Avoid | Use Instead |
+|-------|-------------|
+| robust | strong, reliable, thorough, solid |
+| comprehensive | complete, thorough, full, detailed |
+| pivotal | key, critical, central, important |
+| crucial | important, key, essential, critical |
+| vital | important, essential, necessary |
+| transformative | significant, important, major |
+| cutting-edge | new, advanced, recent, modern |
+| groundbreaking | new, original, significant |
+| innovative | new, original, creative |
+| seamless | smooth, easy, effortless |
+| intricate | complex, detailed, complicated |
+| nuanced | subtle, complex, detailed |
+| multifaceted | complex, varied, diverse |
+| holistic | complete, whole, comprehensive |
+
+---
+
+## Overused Transitions and Connectors
+
+| Avoid | Use Instead |
+|-------|-------------|
+| furthermore | also, in addition, and |
+| moreover | also, and, besides |
+| notwithstanding | despite, even so, still |
+| that being said | however, but, still |
+| at its core | essentially, fundamentally, basically |
+| to put it simply | in short, simply put |
+| it is worth noting that | note that, importantly |
+| in the realm of | in, within, regarding |
+| in the landscape of | in, within |
+| in today's [anything] | currently, now, today |
+
+---
+
+## Phrases That Signal AI Writing
+
+### Opening Phrases to Avoid
+- "In today's fast-paced world..."
+- "In today's digital age..."
+- "In an era of..."
+- "In the ever-evolving landscape of..."
+- "In the realm of..."
+- "It's important to note that..."
+- "Let's delve into..."
+- "Imagine a world where..."
+
+### Transitional Phrases to Avoid
+- "That being said..."
+- "With that in mind..."
+- "It's worth mentioning that..."
+- "At its core..."
+- "To put it simply..."
+- "In essence..."
+- "This begs the question..."
+
+### Concluding Phrases to Avoid
+- "In conclusion..."
+- "To sum up..."
+- "By [doing X], you can [achieve Y]..."
+- "In the final analysis..."
+- "All things considered..."
+- "At the end of the day..."
+
+### Structural Patterns to Avoid
+- "Whether you're a [X], [Y], or [Z]..." (listing three examples after "whether")
+- "It's not just [X], it's also [Y]..."
+- "Think of [X] as [elaborate metaphor]..."
+- Starting sentences with "By" followed by a gerund: "By understanding X, you can Y..."
+
+---
+
+## Filler Words and Empty Intensifiers
+
+These words often add nothing to meaning. Remove them or find specific alternatives:
+
+- absolutely
+- actually
+- basically
+- certainly
+- clearly
+- definitely
+- essentially
+- extremely
+- fundamentally
+- incredibly
+- interestingly
+- naturally
+- obviously
+- quite
+- really
+- significantly
+- simply
+- surely
+- truly
+- ultimately
+- undoubtedly
+- very
+
+---
+
+## Academic-Specific AI Tells
+
+| Avoid | Use Instead |
+|-------|-------------|
+| shed light on | clarify, explain, reveal |
+| pave the way for | enable, allow, make possible |
+| a myriad of | many, numerous, various |
+| a plethora of | many, numerous, several |
+| paramount | very important, essential, critical |
+| pertaining to | about, regarding, concerning |
+| prior to | before |
+| subsequent to | after |
+| in light of | because of, given, considering |
+| with respect to | about, regarding, for |
+| in terms of | regarding, for, about |
+| the fact that | that (or rewrite sentence) |
+
+---
+
+## How to Self-Check
+
+1. Read your text aloud. If phrases sound unnatural in speech, revise them
+2. Ask: "Would I say this in a conversation with a colleague?"
+3. Check for repetitive sentence structures
+4. Look for clusters of the words listed above
+5. Ensure varied sentence lengths (not all similar length)
+6. Verify each intensifier adds genuine meaning

--- a/.agents/skills/seo-audit/references/international-seo.md
+++ b/.agents/skills/seo-audit/references/international-seo.md
@@ -1,0 +1,230 @@
+# International SEO: Evidence & Sources
+
+Detailed evidence backing the International SEO & Localization section of the SEO Audit skill. Organized by topic with source URLs and key quotes.
+
+---
+
+## Hreflang
+
+### Placement Methods
+
+Google supports three equivalent methods: HTML `<link>` in `<head>`, HTTP `Link` headers, and XML sitemap `<xhtml:link>` elements. Google confirmed no method is prioritized over another.
+
+Google combines signals from both HTML and sitemaps. If the same language-region pair points to different URLs across methods, Google drops that pair rather than guessing.
+
+- [Google Search Central: Localized Versions](https://developers.google.com/search/docs/specialty/international/localized-versions)
+- [SEJ: Google Combines Hreflang Signals](https://www.searchenginejournal.com/google-combines-hreflang-signals-from-html-sitemaps/389219/)
+
+### Reciprocal Requirement
+
+Google's docs: "If page X links to page Y, page Y must link back to page X. If not, those annotations may be ignored or not interpreted correctly."
+
+Every page must include itself (self-referencing) in the hreflang set. Missing self-referencing is the #1 error found by Semrush audits. A study of 374,756 domains found 67% of hreflang implementations had issues.
+
+- [Google Search Central: Localized Versions](https://developers.google.com/search/docs/specialty/international/localized-versions)
+- [Semrush: 9 Common Hreflang Errors](https://www.semrush.com/blog/hreflang-errors/)
+- [SE Land: 31% of International Websites Contain Hreflang Errors](https://searchengineland.com/study-31-of-international-websites-contain-hreflang-errors-395161)
+
+### x-default
+
+Introduced April 2013. Designates the fallback page for users whose language/region matches no declared variant. Can point to the same URL as one of the language-specific alternates. Must be included in the complete set of annotations on every variant page.
+
+- [Google Blog: x-default hreflang](https://developers.google.com/search/blog/2013/04/x-default-hreflang-for-international-pages)
+- [Google Blog: How x-default can help you (2023)](https://developers.google.com/search/blog/2023/05/x-default)
+
+### Language & Region Codes
+
+Language: ISO 639-1 (2-letter). Region: ISO 3166-1 Alpha 2 (2-letter). Format: `language[-script][-region]`.
+
+You cannot specify a region code alone. Common mistakes: `en-UK` (should be `en-GB`), `es-419` (not ISO 3166-1). A study found 8.9% of sites using hreflang contain invalid language codes.
+
+- [Google Search Central: Localized Versions](https://developers.google.com/search/docs/specialty/international/localized-versions)
+- [SE Land: 31% Study](https://searchengineland.com/study-31-of-international-websites-contain-hreflang-errors-395161)
+
+### Hreflang at Scale (20+ locales)
+
+With 20 locales, HTML `<head>` hreflang adds ~1.5KB per page for zero user benefit. Sitemap-based hreflang has zero runtime performance impact. `<xhtml:link>` child elements do NOT count toward the 50,000 URL sitemap limit (only `<loc>` elements count).
+
+John Mueller recommends focusing hreflang on pages receiving wrong-language traffic, not every page: "I wouldn't do it for any of the other pages of the site because it's so complex & hard to manage."
+
+- [SERoundtable: Child Elements Don't Count](https://www.seroundtable.com/google-child-elements-dont-count-towards-sitemap-url-limit-34377.html)
+- [SERoundtable: Where To Focus Hreflang](https://www.seroundtable.com/using-hreflang-34127.html)
+- [Yoast: hreflang Ultimate Guide](https://yoast.com/hreflang-ultimate-guide/)
+
+### Google vs Bing
+
+Bing treats hreflang as a "weak signal." Bing relies on `content-language` meta tag, HTML `lang` attribute, ccTLDs, and server location. Yandex supports hreflang like Google.
+
+For both engines: implement hreflang (Google/Yandex) + `<html lang="...">` + `<meta http-equiv="content-language">` (Bing).
+
+- [Digital Ready Marketing: Bing Doesn't Use Hreflang](https://digitalreadymarketing.com/bing-doesnt-use-hreflang-annotation-what-does-it-use/)
+- [Yoast: hreflang Ultimate Guide](https://yoast.com/hreflang-ultimate-guide/)
+
+---
+
+## Canonicalization & i18n
+
+### Self-Referencing Canonicals
+
+Each locale page must canonical to itself. John Mueller: "Don't use a rel=canonical across languages/countries, only use it on a per-country/language basis."
+
+Google's docs: "Specify a canonical page in the same language, or the best possible substitute language if a canonical doesn't exist for the same language."
+
+- [John Mueller: hreflang canonical](https://johnmu.com/hreflang-canonical/)
+- [Google: Consolidate Duplicate URLs](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)
+
+### Canonical Overrides Hreflang
+
+Mueller: "If your canonical is pointing somewhere else, Google will follow that and ignore your hreflang annotation." The canonical URL must be one of the URLs in the hreflang set, or all hreflang markup is ignored.
+
+Google also states: "Google prefers URLs that are part of hreflang clusters for canonicalization" -- when signals align, hreflang strengthens canonical selection.
+
+- [John Mueller: hreflang canonical](https://johnmu.com/hreflang-canonical/)
+- [SEJ: Hreflang Tags Are Hints](https://www.searchenginejournal.com/google-reminds-that-hreflang-tags-are-hints-not-directives/546428/)
+- [Google: Consolidate Duplicate URLs](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)
+
+### Near-Duplicate Regional Variants
+
+Mueller (2023 Office Hours): "If the content is completely the same, and we can't tell any difference, then for simplicity and user experience we may just show one version -- even if hreflang is present."
+
+Google's duplicate detection runs BEFORE hreflang evaluation. To keep both versions indexed, you need substantive content differences beyond currency symbols.
+
+- [International Web Mastery: Same-Language Duplicate Pages](https://internationalwebmastery.com/blog/how-google-handles-canonicalization-of-same-language-duplicate-near-duplicate-pages/)
+- [Google: Managing Multi-Regional Sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites)
+
+### Pagination Across Locales
+
+Google: "Don't use the first page of a paginated sequence as the canonical page. Instead, give each page its own canonical URL." Each paginated page in each locale gets self-referencing canonical. `rel="next/prev"` deprecated March 2019.
+
+- [Google: Pagination Best Practices](https://developers.google.com/search/docs/specialty/ecommerce/pagination-and-incremental-page-loading)
+
+---
+
+## International Sitemaps
+
+### Structure
+
+Each `<url>` entry includes `<xhtml:link>` alternates for every locale. Requires `xmlns:xhtml="http://www.w3.org/1999/xhtml"` namespace.
+
+Split sitemaps by content type, not by locale. Splitting by locale creates maintenance problems because every locale sitemap must reference every other locale (reciprocal requirement).
+
+- [Google Search Central: Localized Versions](https://developers.google.com/search/docs/specialty/international/localized-versions)
+- [Lumar: How Google Handles Hreflang](https://www.lumar.io/office-hours/hreflang/)
+
+### Size Limits
+
+50,000 URLs / 50MB uncompressed per sitemap. Only `<loc>` elements count toward the 50K limit. But with 20 hreflang alternates per entry, the 50MB file size limit becomes the bottleneck. Plan for 2,000-5,000 URLs per sitemap when using full hreflang.
+
+- [Google: Build and Submit a Sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- [SERoundtable: Sitemap 50,000 Limit](https://www.seroundtable.com/google-sitemap-50-000-limit-based-on-location-urls-not-alternative-urls-33843.html)
+
+### Submission
+
+Submit the sitemap index in Search Console AND reference it in robots.txt. Individual child sitemaps can be submitted separately for per-sitemap reporting.
+
+- [Google: Build and Submit a Sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+
+### Next.js Caveat
+
+Next.js `alternates.languages` does NOT automatically include a self-referencing `<xhtml:link>` for the `<loc>` URL. You must explicitly include the `<loc>` URL's own language in the `languages` object.
+
+- [Next.js Docs: sitemap.xml](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)
+
+---
+
+## URL Structure
+
+### Strategies Compared
+
+Google treats subdirectories and subdomains equivalently. Mueller: "From our point of view...they say subdomains and subdirectories are essentially equivalent."
+
+URL parameters (`?lang=en`) are explicitly "Not recommended" per Google docs.
+
+- [Google: Managing Multi-Regional Sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites)
+
+### Default Language
+
+Mueller recommends: set `/` as x-default, put each language in its own prefix. Without marking `/` as x-default, "to Google it can look like '/' is a separate page from the others."
+
+- [Google Blog: x-default](https://developers.google.com/search/blog/2023/05/x-default)
+- [Google Blog: Creating the Right Homepage](https://developers.google.com/search/blog/2014/05/creating-right-homepage-for-your)
+
+### Content Negotiation / IP Redirects
+
+Google strongly advises against locale-adaptive pages. Googlebot crawls from US IPs and does not send Accept-Language headers. Separate URLs + hreflang are required.
+
+- [Google: Locale-Adaptive Pages](https://developers.google.com/search/docs/specialty/international/locale-adaptive-pages)
+
+### Trailing Slash Consistency
+
+Mueller: trailing slash is "a significant part of the URL and will change the URL if it's there or not." Pick one format for all locale paths, internal links, canonicals, hreflang, and sitemaps.
+
+Mueller (2025): "Consistency is the biggest technical SEO factor."
+
+- [SERoundtable: Consistency Is The Biggest Technical SEO Factor](https://www.seroundtable.com/google-consistency-seo-40427.html)
+
+### Search Console Geotargeting
+
+The International Targeting report is deprecated. Google now relies entirely on hreflang, content language analysis, and linking patterns. You can add subdirectory properties for per-locale reporting.
+
+- [Google Support: International Targeting Deprecated](https://support.google.com/webmasters/answer/12474899?hl=en)
+
+### Framework Locale Modes
+
+Use `localePrefix: 'always'` (next-intl) or equivalent. Never hide locale from URLs -- Google needs unique URLs per language. Using `'never'` mode disables alternate links entirely.
+
+- [next-intl: Routing Configuration](https://next-intl.dev/docs/routing/configuration)
+- [Next.js Discussion #18419](https://github.com/vercel/next.js/discussions/18419)
+
+---
+
+## Content Quality Across Locales
+
+### Auto-Translated Content (2025 Stance)
+
+Google removed longstanding guidance advising against auto-translated content in mid-2025. Current stance: "Our policies do not strictly define content that has been translated by AI as spam." The scaled content abuse policy mentions translation as a possible vector, but does not ban it.
+
+Reddit scaled AI translations to 35+ languages with Google's knowledge. The key distinction is intent and quality, not the method.
+
+- [Google Spam Policies](https://developers.google.com/search/docs/essentials/spam-policies)
+- [Glenn Gabe: Auto-Translating Content](https://www.gsqi.com/marketing-blog/auto-translating-content-google-scaled-content-abuse/)
+- [SE Land: Reddit AI Translations](https://searchengineland.com/google-comments-on-reddits-use-of-ai-to-translate-its-pages-456908)
+
+### Thin Locale Pages
+
+Google: "Localized versions of a page are only considered duplicates if the main content of the page remains untranslated." Pages with only translated boilerplate get clustered as duplicates.
+
+Do NOT use noindex for unwanted locale pages (wastes crawl budget). Do NOT canonical cross-locale (conflicts with hreflang). Best approach: don't create locale pages you can't make genuinely helpful.
+
+- [Google: Localized Versions](https://developers.google.com/search/docs/specialty/international/localized-versions)
+- [Google: Crawl Budget Management](https://developers.google.com/search/docs/crawling-indexing/large-site-managing-crawl-budget)
+
+### Helpful Content System Impact
+
+Merged into core ranking March 2024. Site-wide signal: "any content -- not just unhelpful content -- on sites determined to have relatively high amounts of unhelpful content overall is less likely to perform well in Search."
+
+Low-quality translated pages can drag down the entire site. This is the strongest argument against creating locale pages that aren't genuinely helpful.
+
+- [Google Blog: Helpful Content Update](https://developers.google.com/search/blog/2022/08/helpful-content-update)
+- [Amsive: What Changed in 2024](https://www.amsive.com/insights/seo/googles-helpful-content-update-ranking-system-what-happened-and-what-changed-in-2024/)
+
+### Partial Translation
+
+Google: "Translating only the boilerplate text of your pages while keeping the bulk of your content in a single language...can create a bad user experience." Google uses visible content (not lang attribute) to determine page language.
+
+Translate ALL content on a page if you create a locale version. Untranslated metadata (title, description) in the wrong language reduces CTR.
+
+- [Google: Managing Multi-Regional Sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites)
+
+### Crawl Budget
+
+Only a concern for 1M+ pages or 10K+ pages changing daily. But alternate URLs (hreflang targets) do consume crawl budget. Broken hreflang links waste budget AND invalidate signals.
+
+- [Google: Crawl Budget Management](https://developers.google.com/search/docs/crawling-indexing/large-site-managing-crawl-budget)
+- [Google Blog: Crawl Budget](https://developers.google.com/search/blog/2017/01/what-crawl-budget-means-for-googlebot)
+
+### Locale-Specific Signals
+
+Google identifies audience via: "local addresses and phone numbers on the pages, the use of local language and currency, links from other local sites, or signals from your Business Profile."
+
+- [Google: Managing Multi-Regional Sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites)

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,119 @@
+# Contributing
+
+How to land changes in this repo, based on **actual git history** (merge commits and GitHub PRs), not a generic workflow.
+
+## Branch roles
+
+| Branch | Role |
+|--------|------|
+| `main` | What ships / what production (e.g. Cloudflare Pages) tracks. |
+| `develop` | Integration branch: day-to-day work lands here first. |
+| `feature/<topic>` | Short-lived branch for a focused change set (recommended for PRs). |
+
+Historically, work has often been committed directly on `develop`, then promoted. For **new contributors and LLM agents**, prefer a **feature branch + PR** so review and scope stay clear.
+
+## How changes reach `main` (observed pattern)
+
+1. Work is integrated on **`develop`** (commits and/or PRs into `develop`).
+2. **`main` is updated only via GitHub pull requests** that merge `develop` into `main`, using **merge commits** (messages look like `Merge pull request #N from n0nuser/develop`).
+3. **`develop` is sometimes synced from `main`** with a merge (messages like `Merge remote-tracking branch 'origin/main' into develop`) so both lines stay aligned after a release.
+
+There is **no evidence** in recent history of `main` being advanced by rebase-only or squash-only promotion; the default integration style here is **merge**.
+
+```mermaid
+flowchart LR
+  feature[feature_topic] --> prDev[PR_into_develop]
+  prDev --> develop[develop]
+  develop --> prMain[PR_develop_into_main]
+  prMain --> main[main]
+```
+
+## Standard flow (recommended)
+
+### 1. Start from current `develop`
+
+```powershell
+git fetch origin
+git checkout develop
+git pull origin develop
+```
+
+### 2. Create a feature branch
+
+```powershell
+git checkout -b feature/your-topic
+```
+
+Use a short, kebab-style topic: `feature/seo-notes`, `feature/fix-search`, etc.
+
+### 3. Make changes and validate
+
+Follow [docs/project-guide.md](docs/project-guide.md) for Hugo, lint, and deploy notes.
+
+### 4. Commit with a clear message
+
+This project uses **Conventional Commits**-style subjects in recent history, for example:
+
+- `feat: ...`
+- `fix: ...`
+- `chore: ...`
+- `docs: ...`
+
+Keep the subject imperative and under ~72 characters when possible.
+
+### 5. Open PR → `develop`
+
+```powershell
+git push -u origin feature/your-topic
+gh pr create --base develop --head feature/your-topic --title "..." --body "..."
+```
+
+Prefer **Create a merge commit** on GitHub when merging the PR (matches existing history). If your repo settings force squash or rebase, follow the setting—but then local expectations may differ from the merge-based history above.
+
+### 6. After merge: promote `develop` → `main` (when ready to release)
+
+When `develop` contains what you want live:
+
+```powershell
+git checkout develop
+git pull origin develop
+gh pr create --base main --head develop --title "..." --body "Promote develop to main."
+```
+
+Merge that PR the same way you merged into `develop`.
+
+### 7. Keep `develop` aligned with `main` (as needed)
+
+If `main` moved and you need those commits on `develop`:
+
+```powershell
+git checkout develop
+git pull origin develop
+git merge origin/main
+# resolve conflicts if any, then:
+git push origin develop
+```
+
+## If you hit merge conflicts
+
+1. Run `git status` and fix files Git lists.
+2. Prefer minimal edits: keep intent from both sides when both matter.
+3. `git add` the resolved paths, then `git commit` (completes the merge).
+4. Push the branch and finish the PR.
+
+## LLM / agent checklist (copy-paste discipline)
+
+Use this so automated helpers do not smuggle unrelated edits into a PR.
+
+- [ ] **Branch**: created from up-to-date `develop` as `feature/<topic>`.
+- [ ] **Scope**: only intentional paths are staged (`git diff --staged`).
+- [ ] **No secrets**: no API keys, tokens, or personal identifiers in commits.
+- [ ] **Destructive git**: no `git reset --hard`, force-push, or history rewrite unless the human explicitly asked.
+- [ ] **Push / deploy**: only when the human asked for that step.
+- [ ] **Promotion order**: merge to `develop` first; open `develop` → `main` only when releasing.
+- [ ] **Document**: if you change how we work, update this file and the relevant section in [docs/project-guide.md](docs/project-guide.md).
+
+## Quick reference
+
+- Project guide: [docs/project-guide.md](docs/project-guide.md)
+- Agent rules: [AGENTS.md](AGENTS.md)

--- a/docs/project-guide.md
+++ b/docs/project-guide.md
@@ -143,6 +143,8 @@ The following milestones were extracted with a low-cost strategy (recent window 
 
 ## Recommended Contributor Workflow
 
+For branch strategy, PR order (`feature` → `develop` → `main`), and merge-based integration as used in this repo, see [contributing.md](../contributing.md).
+
 1. Create or edit content using existing archetype/front matter patterns.
 2. Preview with Hugo locally.
 3. Validate generated output and key pages.
@@ -151,6 +153,7 @@ The following milestones were extracted with a low-cost strategy (recent window 
 
 ## Canonical References
 
+- [contributing.md](../contributing.md)
 - `README.md`
 - `config.toml`
 - `deploy.sh`

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "seo-audit": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/seo-audit/SKILL.md",
+      "computedHash": "8d29f46f5d494dd41d65b7d1539b0e4bd7e1b5f4d73b8316cd1e744764705594"
+    }
+  }
+}


### PR DESCRIPTION
Adds contributing.md documenting merge-based develop/main flow, links from docs/project-guide.md, seo-audit skill under .agents/, and skills-lock.json.

TASKS.md deletion was intentionally excluded from this PR.