### PR TITLE
fix(seo): taxonomy titles, robots, HSTS

### DIFF
--- a/docs/project-guide.md
+++ b/docs/project-guide.md
@@ -101,6 +101,9 @@ n0nuser.github.io/
 
 - Google Search Console property has been added for this site.
 - Ads policy: no ads are served on this site; keep `ads.txt` aligned with this policy if published.
+- Crawler policy source of truth is Cloudflare's managed `robots.txt` (Content-Signal directive and AI-bot disallow list). The repo file `static/robots.txt` only carries the `Sitemap:` reference to avoid duplicate `User-agent: *` blocks in the served output.
+- Response headers are configured via `static/_headers` (Cloudflare Pages format). HSTS is set to `max-age=31536000` (1 year) without `includeSubDomains` and without `preload`. To enable `includeSubDomains`, first confirm every subdomain serves HTTPS correctly. `preload` should only be added after an explicit decision because submission to the HSTS preload list is effectively permanent.
+- If the Cloudflare dashboard HSTS setting (SSL/TLS -> Edge Certificates -> HSTS) is also enabled, align it with the `_headers` value or disable it to avoid duplicate `Strict-Transport-Security` headers in responses.
 
 ### Existing Automation and Scripts
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -22,9 +22,9 @@
 .Paginator.TotalPages) }}
 {{ end }}
 
-{{ else if (and (ne .Kind "taxonomyTerm") (eq .Type "tags")) }}
+{{ else if (and (eq .Kind "term") (eq .Type "tags")) }}
 
-<!-- If it's a post list for a tag -->
+<!-- Single tag term page (e.g., /tags/linux/) -->
 {{ $currentTitle = printf "%s: \"%s\"" (T "tag") .Title }}
 
 {{ if gt .Paginator.TotalPages 1 }}
@@ -34,15 +34,25 @@
 {{ $mainTitle = printf "%s: \"%s\"" (T "tag") .Title }}
 {{ end }}
 
-{{ else if (and (eq .Kind "taxonomyTerm") (eq .Type "tags")) }}
+{{ else if (and (or (eq .Kind "taxonomy") (eq .Kind "taxonomyTerm")) (eq .Type "tags")) }}
 
-<!-- /categories/ page -->
+<!-- Tags taxonomy root (e.g., /tags/) -->
 {{ $currentTitle = (T "tags") }}
 
-{{ else if (and (eq .Kind "taxonomyTerm") (eq .Type "categories")) }}
+{{ if gt .Paginator.TotalPages 1 }}
+{{ $mainTitle = printf "%s, %s %s %s %s" (T "tags") (T "page") (string .Paginator.PageNumber) (T "of") (string
+.Paginator.TotalPages) }}
+{{ end }}
 
-<!-- /tags/ page -->
+{{ else if (and (or (eq .Kind "taxonomy") (eq .Kind "taxonomyTerm")) (eq .Type "categories")) }}
+
+<!-- Categories taxonomy root (e.g., /categories/) -->
 {{ $currentTitle = (T "categories") }}
+
+{{ if gt .Paginator.TotalPages 1 }}
+{{ $mainTitle = printf "%s, %s %s %s %s" (T "categories") (T "page") (string .Paginator.PageNumber) (T "of") (string
+.Paginator.TotalPages) }}
+{{ end }}
 
 {{ else if and (.IsHome) (not .Content) }}
 
@@ -56,11 +66,11 @@
 
 {{ if .IsHome }}
 {{ $currentDesc = (.Site.Params.description | emojify) }}
-{{ else if and (ne .Kind "taxonomyTerm") (eq .Type "tags") (not .Params.description) }}
+{{ else if and (eq .Kind "term") (eq .Type "tags") (not .Params.description) }}
 {{ $currentDesc = (T "posts_under_tag" .) }}
-{{ else if and (ne .Kind "taxonomyTerm") (eq .Type "categories") (not .Params.description) }}
+{{ else if and (eq .Kind "term") (eq .Type "categories") (not .Params.description) }}
 {{ $currentDesc = (T "posts_under_category" .) }}
-{{ else if eq .Kind "taxonomyTerm" }}
+{{ else if or (eq .Kind "taxonomy") (eq .Kind "taxonomyTerm") }}
 {{ $currentDesc = printf "%s %s." (T "page_containing") ($currentTitle | lower) }}
 {{ else if (eq .Kind "404") }}
 {{ $currentDesc = .Site.Params.notFound.description | default hugo.Data.default.notFound.description }}

--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,10 @@
+# Cloudflare Pages headers configuration
+# Docs: https://developers.cloudflare.com/pages/configuration/headers/
+#
+# HSTS hardening: bump max-age from 30 days (Cloudflare default) to 1 year.
+# `includeSubDomains` and `preload` are intentionally omitted until all
+# subdomains are confirmed HTTPS-ready and a deliberate preload submission
+# is approved (preload is effectively irreversible).
+
+/*
+  Strict-Transport-Security: max-age=31536000

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,5 @@
-User-agent: *
-Allow: /
+# Crawler policy is managed at the Cloudflare edge (Content-Signal,
+# AI-bot disallow list, etc.). This file only provides repo-managed
+# additions that Cloudflare does not inject.
+
 Sitemap: https://pablogonzalez.me/sitemap.xml


### PR DESCRIPTION
Implements SEO action plan: Hugo 0.159 taxonomy/term title and meta description fixes; Cloudflare as robots policy source with repo Sitemap only; Cloudflare Pages _headers for 1-year HSTS; project-guide notes. See contributing.md merge flow.