### PR TITLE
feat: refresh home layout and header branding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,3 +89,7 @@ Before finalizing work:
 ## Deployment Note
 
 - Typical Cloudflare deployment time is about 2 minutes.
+
+## Running hugo in local
+
+Use: `hugo server --disableFastRender --noHTTPCache --ignoreCache`.

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -1,23 +1,152 @@
-// Home hero highlights (colorines estilo carol.gg)
+// Site header — mobile: brand stacked; desktop: brand row + links row
+
+body > header {
+  --header-stack-gap: 1rem;
+  --brand-font-size: 1.125rem;
+  --brand-line-height: 1.25;
+  --brand-avatar-size: 3rem;
+
+  padding: 1rem 15px;
+  border-bottom: 1px solid var(--fg);
+
+  .site-header-inner {
+    max-width: 55rem;
+    margin: 0 auto;
+  }
+
+  .site-nav {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--header-stack-gap);
+    margin: 0;
+    padding: 0;
+  }
+
+  .site-nav-brand {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  // Theme sets margin: 1.8rem on all img — must reset here or avatar overlaps name / spills past header
+  img.site-brand-avatar {
+    margin: 0;
+    max-height: none;
+  }
+
+  .site-brand-avatar-link {
+    display: block;
+    flex: 0 0 auto;
+    width: fit-content;
+    height: fit-content;
+    margin: 0;
+    padding: 0;
+    line-height: 0;
+    font-size: 0;
+    text-decoration: none;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 0.9;
+    }
+
+    img.site-brand-avatar {
+      display: block;
+      width: var(--brand-avatar-size);
+      height: auto;
+    }
+  }
+
+  .site-brand-name {
+    font-family: $heading-font;
+    font-size: var(--brand-font-size);
+    font-weight: $heading-bold-weight;
+    line-height: var(--brand-line-height);
+    color: var(--alt-fg);
+    text-decoration: none;
+
+    &:hover {
+      opacity: 0.85;
+    }
+  }
+
+  .site-nav-links {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 0.25rem 1rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    a {
+      display: inline-block;
+      margin: 0;
+      padding: 0.2rem 0.1rem 0.3rem;
+      font-size: 1rem;
+      line-height: 1.15;
+      font-weight: $heading-bold-weight;
+      text-transform: lowercase;
+      color: var(--fg);
+      text-decoration: none;
+      word-break: normal;
+      border-bottom: 0.2rem solid var(--accent);
+    }
+  }
+
+  @include respond-above($mobile-breakpoint) {
+    --brand-avatar-size: 2.75rem;
+
+    padding: 1.25rem 15px;
+
+    .site-nav {
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .site-nav-brand {
+      flex-direction: row;
+      gap: 0.75rem;
+    }
+
+    .site-nav-links {
+      justify-content: flex-end;
+    }
+  }
+}
+
+body > header + .filler {
+  padding-top: 2.5rem;
+
+  @include respond-above($mobile-breakpoint) {
+    padding-top: 3rem;
+  }
+}
+
+// Home page
 
 .index {
   .home-hero {
-    margin: 2.5rem 0 3rem;
+    margin: 2.5rem 0 2.5rem;
     display: grid;
     gap: 1.5rem;
 
     @media (min-width: 768px) {
-      grid-template-columns: minmax(0, 260px) minmax(0, 1fr);
+      grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
       align-items: center;
     }
 
     .home-hero-photo {
-      max-width: 260px;
+      max-width: 220px;
       margin: 0 auto;
     }
 
     .home-hero-copy {
-      max-width: 40rem;
+      max-width: 38rem;
     }
   }
 
@@ -42,9 +171,29 @@
     margin: 0;
     line-height: 1.7;
   }
+
+  .home-posts {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+
+    li {
+      margin-bottom: 1.25rem;
+    }
+
+    a {
+      font-weight: $heading-weight;
+    }
+
+    time {
+      display: block;
+      margin-top: 0.25rem;
+      font-size: 0.85rem;
+      opacity: 0.7;
+    }
+  }
 }
 
-// Big underline highlight behind text
 .home-highlight {
   position: relative;
   font-weight: $heading-bold-weight;
@@ -53,7 +202,6 @@
   background-size: 100% 100%;
 }
 
-// Light mode highlight colors (only underline, not text)
 html[data-mode='light'] {
   .home-highlight--yellow {
     background-image: linear-gradient(
@@ -86,7 +234,6 @@ html[data-mode='light'] {
   }
 }
 
-// Dark mode underline colors (slightly stronger to be visible)
 html[data-mode='dark'] {
   .home-highlight--yellow {
     background-image: linear-gradient(

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,8 @@
 baseURL = "https://pablogonzalez.me"
 locale = "en"
 title = "Pablo González"
-copyright = "Copyright © 2024, Pablo Jesús González Rubio\n All rights reserved."
+# Year range is rendered at build time in layouts/partials/custom/copyright.html
+copyright = ""
 
 enableEmoji = false # It transcodes emojis from hex codeblock
 # Ideal solution: hardcode it in text
@@ -26,6 +27,8 @@ noClasses = false
 
 [params]
 
+copyrightStartYear = 2021
+
 # Google Analytics ID
 # GA4 = "G-GWC49NSYGC" # Google Analytics 4
 
@@ -34,6 +37,7 @@ description = "Backend development, Linux, and cybersecurity posts by Pablo Gonz
 
 # Author
 author = "Pablo Jesús González Rubio"
+brandName = "Pablo González"
 authorDesc = 'Python Developer. "n0nuser" is my alias'
 
 # Site cover, for Open Graph, Twitter Cards and Schema.org
@@ -277,26 +281,33 @@ label = "English"
 [languages.en.menu]
 
 [[languages.en.menu.main]]
-identifier = "home"
-name = "Home"
-weight = 1
-url = "/"
-[[languages.en.menu.main]]
-identifier = "home"
-name = "Home"
-weight = 1
-url = "/"
-
-[[languages.en.menu.main]]
 identifier = "about"
 name = "About"
 weight = 2
 url = "about/"
 
 [[languages.en.menu.main]]
+identifier = "resume"
+name = "Resume"
+weight = 3
+url = "resume/"
+
+[[languages.en.menu.main]]
+identifier = "now"
+name = "Now"
+weight = 4
+url = "now/"
+
+[[languages.en.menu.main]]
+identifier = "uses"
+name = "Uses"
+weight = 5
+url = "uses/"
+
+[[languages.en.menu.main]]
 identifier = "posts"
 name = "Posts"
-weight = 5
+weight = 6
 url = "posts/"
 
 # [[languages.en.menu.main]]
@@ -329,4 +340,4 @@ url = "tags/"
 identifier = "contact"
 name = "Contact"
 weight = 8
-url = "#contact"
+url = "/#contact"

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,6 +8,12 @@ imgPath: "."
 disableTitleSeparator: false
 cover: "me.webp"
 coverAlt: "Pablo González Image"
+social:
+  centralized:
+    github: ["n0nuser"]
+    linkedin: ["nonuser"]
+    gmail: ["contact@pablogonzalez.me"]
+    rss: ["pablogonzalez.me/index.xml"]
 ---
 
 <section class="home-hero">
@@ -16,39 +22,19 @@ coverAlt: "Pablo González Image"
   </div>
   <div class="home-hero-copy">
     <p class="home-hero-kicker">
-      <span class="home-highlight home-highlight--yellow">Hey there!</span>
+      <span class="home-highlight home-highlight--yellow">Hey there! 👋🏻</span>
     </p>
-    <h2 class="home-hero-title">
+    <h1 class="home-hero-title">
       <span class="home-highlight home-highlight--mint">My name is Pablo,</span><br />
       <span class="home-highlight home-highlight--pink">and this is my little home on the internet.</span>
-    </h2>
+    </h1>
     <p class="home-hero-lede">
-      I'm a Computer Engineer focused on backend development with Python. I enjoy building API-first services, improving software architecture, and keeping codebases maintainable with practical clean code habits.
+      I'm a computer engineer focused on backend development with Python — API-first services, maintainable architecture, and practical notes on software, Linux, and security from real projects and labs.
     </p>
   </div>
 </section>
 
-This website is my technical space where I publish posts and notes about software development, Linux administration, and security topics that I use in real projects and hands-on labs. I write in a practical format so I can revisit each guide quickly, and so other developers can apply the same ideas without too much setup.
-
-If you want a quick overview of my background, current focus, and tools, start here:
-
-* 🙍🏻‍♂️ [About Me](/about)
-* 📄 [Resume](/resume)
-* ⏳ [Now](/now)
-* 🛠️ [What I Use](/uses)
-
-## Posts and Development Topics
-
-You can also browse the [blog](/posts) 📝 by topic:
-
-* [Software Development](tags/software-development/): backend engineering practices, architecture decisions, and coding workflows.
-* [Cheatsheets](tags/cheatsheet/): concise command references and troubleshooting shortcuts.
-* [Linux Posts](tags/linux/): system administration notes, hardening basics, and server operations.
-* [Hack The Box Writeups](writeups/htb/): security challenge writeups and exploitation walkthroughs.
-
-If you are curious about traffic, [public site analytics are available](https://cloud.umami.is/share/sMn2hgzqZZ0lEpde/pablogonzalez.me).
-
-I update this site whenever I discover a better approach, fix an old process, or learn something worth documenting. If a post helps you, feel free to reach out and share improvements or corrections.
+{{< home-recent-posts >}}
 
 ## Contact
 

--- a/content/about.md
+++ b/content/about.md
@@ -9,7 +9,9 @@ cover: "me.webp"
 coverAlt: "Me!"
 ---
 
-{{< imgRounded "me.webp" "Photo of Pablo" "borderless" "400" >}}
+{{< imgRounded "me.webp" "Photo of Pablo" "borderless" "400" "high" >}}
+
+> __Updated on May, 15rd of 2026__
 
 Hello there! I’m Pablo 👋, a Computer Engineer with a deep dive into backend development, microservices, a passion for crafting performant systems 🚀 and a Clean Code advocate 🥑. My professional life is driven by a love for Python 🐍, a desire for creating robust system architectures 🏗️, and a continuous quest for improving code quality ✨.
 
@@ -20,31 +22,22 @@ For a more detailed look into my professional journey, skills, and personal inte
 When I'm not working you might find me:
 
 * Listening to music almost anytime 🎵
+  * +400 genres listened (according to Spotify Wrapped 2025)
+  * Huge fan of $uicideboy$
 * Spending quality time with my family and friends 🍻
 * Empowering my digital Diogenes syndrome 🎮
+  * 565 Steam games as of 15/05/2026
+  * +800h. at Skyrim and around 700h at Dark Souls 3
 * Power-lifting things (Deadlift PR of 160KG and now exercising with 24KG Kettlebell) 🏋️‍♂️
-* Nurturing my plants, when I remember to do it 🪴
-* Improving my [Tai Otoshi](https://www.youtube.com/watch?v=ts8Vb2e057Q) 🥋
-* Searching my will to read good dark fantasy books I've been lurking for a while 📚
+* Searching my will to read good dark fantasy books/mangas I've been lurking for a while 📚
+  * Loved Berserk, came in a difficult moment of my life and helped me a lot ⚔️
+  * Currently reading Akira 🏍️
+  * Have Uzumaki by Junji Ito gathering dust 😪
 
-As a matter fact, my favourite food is ramen 🍜, and I'm always up for a good bowl of it!
-Although I won't say no to a good Tonkatsu hehe 🍛
 
-Also, thinking of it now... Spanish omelette 🍳, Hornazo 🥪, Farinato, a good BBQ...
-
-Writing this made me hungry... 🤤😅
-
-**Edit\*\*\*\*** Forgot to say that I'm a big chugger of music, I listen to almost anything, but there are some music styles that aren't really known and I love them:
-
-* [Phonk](https://open.spotify.com/playlist/2Vyaj3fSShTPTsQyDZHX7e) and [Hard Phonk](https://open.spotify.com/playlist/3NoOfDRiNDTEqcJiWyF7oa) 🎌
-* [G-House](https://open.spotify.com/playlist/51TYvBYIBk0wvGyNubhJCD) 🥵
-* [Nordic](https://open.spotify.com/playlist/7Df8RvCjCf5bx1PP2lroZ7) 🇳🇴
-* [Peace](https://open.spotify.com/playlist/3HUq2YvDGQFppevbmFnRyH) and [Chill](https://open.spotify.com/playlist/18HfFl8gx4etyuOjjPXWSG) 🕊️
-* [Sci-Fi](https://open.spotify.com/playlist/2KMP2mCrKF0MTG7QPLFJA6) 🚀
-* [Hyper-Pop](https://open.spotify.com/playlist/51GQ3RJTejomooBzBHvLJN) 🤯
-
-You can see the rest of my playlists on [my Spotify playlists page](https://open.spotify.com/user/orl1r6ro371sob7h4jvk06sse/playlists) 🎧
 
 ## Say hi
 
 {{< social >}}
+
+Curious about traffic? [Public site analytics](https://cloud.umami.is/share/sMn2hgzqZZ0lEpde/pablogonzalez.me) (Umami, privacy-friendly).

--- a/editBlog.sh
+++ b/editBlog.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 IP=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p')
-xdg-open content/posts/
-code .
-nohup firefox $IP:1313 &
-hugo server --bind $IP --baseURL http://$IP:1313
+hugo server --bind $IP --baseURL http://$IP:1313 --gc --disableFastRender --noHTTPCache --ignoreCache
 

--- a/layouts/_default/index.xml
+++ b/layouts/_default/index.xml
@@ -10,9 +10,7 @@
       <language>{{ . }}</language>
     {{end}}
     
-    {{ with .Site.Copyright }}
-      <copyright>{{ . | markdownify | plainify }}</copyright>
-    {{end}}
+    <copyright>{{ partial "copyright-notice" . | plainify }}</copyright>
     
     {{ if not .Date.IsZero }}
       <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>

--- a/layouts/partials/copyright-notice.html
+++ b/layouts/partials/copyright-notice.html
@@ -1,0 +1,6 @@
+{{ $start := .Site.Params.copyrightStartYear | default 2024 }}
+{{ $year := now.Year }}
+{{ $displayYear := printf "%d" $start }}
+{{ if gt $year $start }}{{ $displayYear = printf "%d–%d" $start $year }}{{ end }}
+{{ $holder := .Site.Params.author | default .Site.Title }}
+Copyright © {{ $displayYear }}, {{ $holder }}. All rights reserved.

--- a/layouts/partials/custom/copyright.html
+++ b/layouts/partials/custom/copyright.html
@@ -1,0 +1,6 @@
+{{ $start := .Site.Params.copyrightStartYear | default 2024 }}
+{{ $year := now.Year }}
+{{ $displayYear := printf "%d" $start }}
+{{ if gt $year $start }}{{ $displayYear = printf "%d–%d" $start $year }}{{ end }}
+{{ $holder := .Site.Params.author | default .Site.Title }}
+<p>Copyright © {{ $displayYear }}, {{ $holder }}<br>All rights reserved.</p>

--- a/layouts/partials/custom/site-title.html
+++ b/layouts/partials/custom/site-title.html
@@ -1,0 +1,5 @@
+{{ $home := .Site.Home }}
+<div class="site-nav-brand">
+  <a class="site-brand-avatar-link" href="{{ "/" | relLangURL }}" aria-label="Go to homepage">{{- partial "nav-avatar-img" $home -}}</a>
+  <a class="site-brand-name" href="{{ "/" | relLangURL }}">{{ .Site.Params.brandName | default .Site.Title }}</a>
+</div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,17 +1,15 @@
-<!-- Custom or default site title -->
-{{/*  {{ if or (templates.Exists "partials/custom/site-title") (templates.Exists "partials/custom/site-title.html") }}
-  {{ partial "custom/site-title" . }}
-{{ else }}
-  <a href="{{ .Site.BaseURL | relLangURL }}" style="text-transform:uppercase">{{ .Site.Params.Author }}</a>
-{{ end }}  */}}
+<div class="site-header-inner">
+  <nav class="site-nav" aria-label="{{ T "main_menu" }}">
+    {{ partial "custom/site-title" . }}
 
-<!-- Menu -->
-{{ if .Site.Menus.main }}
-    <nav aria-label="{{ T "main_menu" }}">
-      <ul>
+    {{ if .Site.Menus.main }}
+      <ul class="site-nav-links">
         {{ range .Site.Menus.main }}
-          <li><a class="btnHeader" href="{{ .URL | relLangURL }}">{{ .Name }}</a></li>
+          <li>
+            <a class="site-nav-link btnHeader" href="{{ .URL | relLangURL }}">{{ .Name }}</a>
+          </li>
         {{ end }}
       </ul>
-    </nav>
-{{ end }}
+    {{ end }}
+  </nav>
+</div>

--- a/layouts/partials/nav-avatar-img.html
+++ b/layouts/partials/nav-avatar-img.html
@@ -1,0 +1,19 @@
+{{- $page := . -}}
+{{- $file := "me.webp" -}}
+{{- $altText := $page.Site.Params.brandName | default $page.Site.Title -}}
+{{- $imageProc := dict
+  "highRes" ($page.Site.Params.imageProc.highRes | default hugo.Data.default.imageProc.highRes)
+  "mediumRes" ($page.Site.Params.imageProc.mediumRes | default hugo.Data.default.imageProc.mediumRes)
+  "lowRes" ($page.Site.Params.imageProc.lowRes | default hugo.Data.default.imageProc.lowRes)
+-}}
+{{- $imgPath := $page.Param "imgPath" -}}
+{{- if $imgPath }}{{ $file = path.Join $imgPath $file }}{{ end -}}
+{{- with $page.Resources.GetMatch $file -}}
+{{- $inputFile := . -}}
+{{- $mediumRes := index $imageProc.mediumRes 0 -}}
+{{- $outputSet := slice -}}
+{{- range $imageProc -}}
+{{- $outputSet = $outputSet | append (printf "%s %s" ($inputFile.Resize (index . 0)).RelPermalink (index . 1)) -}}
+{{- end -}}
+<img class="borderless roundedImage site-brand-avatar" srcset="{{ delimit $outputSet ", " }}" src="{{ ($inputFile.Resize $mediumRes).RelPermalink }}" loading="eager" fetchpriority="high" decoding="async"{{ with $altText }} alt="{{ . }}"{{ end }}>
+{{- end -}}

--- a/layouts/shortcodes/home-recent-posts.html
+++ b/layouts/shortcodes/home-recent-posts.html
@@ -1,0 +1,21 @@
+{{ $recent := where .Site.RegularPages "Section" "eq" "posts" }}
+{{ $recent = where $recent "Draft" "!=" true }}
+{{ $recent = $recent.ByDate.Reverse }}
+{{ $shown := 0 }}
+{{ $max := 3 }}
+
+{{ if $recent }}
+  <h2>Recent writing</h2>
+  <ul class="home-posts">
+    {{ range $recent }}
+      {{ if ge $shown $max }}{{ break }}{{ end }}
+      {{ if strings.Contains (lower .Title) "wip" }}{{ continue }}{{ end }}
+      <li>
+        <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+        {{ if not .Date.IsZero }}<time datetime="{{ .Date | dateFormat "2006-01-02" }}">{{ .Date.Format "2 Jan 2006" }}</time>{{ end }}
+      </li>
+      {{ $shown = add $shown 1 }}
+    {{ end }}
+  </ul>
+  <p><a href="{{ "posts/" | relLangURL }}">Read more</a></p>
+{{ end }}


### PR DESCRIPTION
## Summary

- Refresh home page content and add a `home-recent-posts` shortcode for recent articles.
- Update header with nav avatar partial, custom site title, and build-time copyright year range.
- Extend nav menu (Resume, Now, Uses), tune `config.toml` branding params, and style updates in `custom.scss`.
- Minor updates to About page, RSS index partial, `editBlog.sh`, and local Hugo dev note in `AGENTS.md`.

## Test plan

- [x] `hugo --gc --minify` builds successfully (88 pages)
- [ ] Review home, about, and header in local `hugo server`
- [ ] Confirm nav links (Resume, Now, Uses, Posts) resolve correctly
- [ ] Verify copyright footer shows correct year range after deploy
