### PR TITLE
feat: add code-aware reading time labels

### DIFF
--- a/assets/js/postpone.js
+++ b/assets/js/postpone.js
@@ -111,6 +111,10 @@ function populateResults(result) {
     // Date as it should be rendered if not null
     const formatedDate = '<time datetime=' + value.item.date + '>' + value.item.date + '</time>';
 
+    const readingTime = value.item.readingTime
+      ? '<span class=reading-time>' + value.item.readingTime + '</span>'
+      : '';
+
     // Pull template from hugo template definition
     const templateDefinition = document.getElementById('search-result-template').innerHTML;
 
@@ -118,6 +122,7 @@ function populateResults(result) {
     const output = render(templateDefinition, {
       link: value.item.permalink,
       date: value.item.date ? formatedDate : '',
+      readingTime: readingTime,
       title: value.item.title
     });
     document.getElementById('search-results').appendChild(htmlToElement(output))

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -185,12 +185,28 @@ body > header + .filler {
       font-weight: $heading-weight;
     }
 
-    time {
+    .post-card-meta {
       display: block;
       margin-top: 0.25rem;
       font-size: 0.85rem;
       opacity: 0.7;
     }
+
+    time,
+    .reading-time {
+      display: block;
+    }
+
+    .reading-time {
+      margin-top: 0.15rem;
+    }
+  }
+}
+
+article header .post-meta {
+  .reading-time {
+    font-size: inherit;
+    opacity: 0.85;
   }
 }
 

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -712,7 +712,16 @@ article>header {
       margin: 0;
     }
 
-    time {
+    .post-card-meta {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 0.15rem;
+      margin-left: 1.8rem;
+    }
+
+    time,
+    .reading-time {
       // HACK
       // Using a background-image as an overlay...
       background-image:
@@ -723,7 +732,6 @@ article>header {
 
       font-size: .85rem;
 
-      margin-left: 1.8rem;
       padding: 0 9px 2px;
     }
   }
@@ -735,7 +743,8 @@ article>header {
     flex-direction: column-reverse;
     align-items: unset;
 
-    time {
+    .post-card-meta {
+      align-items: unset;
       margin: .3rem 0;
     }
   }

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -46,6 +46,9 @@ other = "Published on"
 [last_updated_on]
 other = "Last updated on"
 
+[min_read]
+other = "min read"
+
 [name]
 other = "Name"
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -37,7 +37,10 @@
                 {{ end }}
                 {{ end }}
               </p>
-              {{ if not .Date.IsZero }}<time datetime="{{ .Date | dateFormat "2006-01-02" }}">{{ .Date.Format "2006-01-02" }}</time>{{ end }}
+              <span class="post-card-meta">
+                {{ if not .Date.IsZero }}<time datetime="{{ .Date | dateFormat "2006-01-02" }}">{{ .Date.Format "2006-01-02" }}</time>{{ end }}
+                {{ partial "reading-time" . }}
+              </span>
             </a>
           </li>
         {{ end }}

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -13,7 +13,7 @@
       <!-- x-js-template -->
     </ul>
     
-    <script id=search-result-template type=text/x-js-template><li><a class=btn href='${link}'><p>${title}</p>${date}</a></li></script>
+    <script id=search-result-template type=text/x-js-template><li><a class=btn href='${link}'><p>${title}</p><span class=post-card-meta>${date}${readingTime}</span></a></li></script>
   
   </main>
 

--- a/layouts/_default/search.json.json
+++ b/layouts/_default/search.json.json
@@ -73,7 +73,7 @@
   {{- end -}}
   
   
-  {{- $.Scratch.Add "index" (dict "title" (.Title | emojify) "date" ($.Scratch.Get "date") "description" ($.Scratch.Get "description") "content" ($.Scratch.Get "uniqueContent") "permalink" .Permalink "tags" ($.Scratch.Get "tags")) -}}
+  {{- $.Scratch.Add "index" (dict "title" (.Title | emojify) "date" ($.Scratch.Get "date") "description" ($.Scratch.Get "description") "content" ($.Scratch.Get "uniqueContent") "permalink" .Permalink "tags" ($.Scratch.Get "tags") "readingTime" (partial "reading-time" (dict "page" $page "format" "value"))) -}}
   
   {{- $.Scratch.Delete "currentWords" -}}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -23,12 +23,17 @@
           </section>
         {{- end -}}
         
-        {{ if not .Date.IsZero }}
-          <p>
-            {{ if eq .PublishDate .Lastmod }}
-              {{ T "published_on" }} <time datetime="{{ .PublishDate.Format "2006-01-02" }}">{{ .PublishDate.Format "2006-01-02" }}</time>
-            {{ else }}
-              {{ T "last_updated_on" }} <time datetime="{{ .Lastmod.Format "2006-01-02" }}">{{ .Lastmod.Format "2006-01-02" }}</time>
+        {{ if or (not .Date.IsZero) .RawContent }}
+          <p class="post-meta">
+            {{ if not .Date.IsZero }}
+              {{ if eq .PublishDate .Lastmod }}
+                {{ T "published_on" }} <time datetime="{{ .PublishDate.Format "2006-01-02" }}">{{ .PublishDate.Format "2006-01-02" }}</time>
+              {{ else }}
+                {{ T "last_updated_on" }} <time datetime="{{ .Lastmod.Format "2006-01-02" }}">{{ .Lastmod.Format "2006-01-02" }}</time>
+              {{ end }}
+            {{ end }}
+            {{ if .RawContent }}
+              {{ if not .Date.IsZero }} · {{ end }}{{ partial "reading-time" . }}
             {{ end }}
           </p>
         {{ end }}

--- a/layouts/partials/reading-time.html
+++ b/layouts/partials/reading-time.html
@@ -1,0 +1,31 @@
+{{- $page := . -}}
+{{- $format := "html" -}}
+{{- if reflect.IsMap . -}}
+  {{- $page = index . "page" -}}
+  {{- with index . "format" }}{{ $format = . }}{{ end -}}
+{{- end -}}
+
+{{- $content := $page.RawContent -}}
+{{- if not $content -}}
+  {{- $content = $page.Content -}}
+  {{- $content = replaceRE "(?s)<div class=\"highlight\".*?</div>" "" $content -}}
+  {{- $content = replaceRE "(?s)<pre.*?</pre>" "" $content -}}
+{{- else -}}
+  {{- $content = replaceRE "(?s)```[\\s\\S]*?```" "" $content -}}
+  {{- $content = replaceRE "(?s)~~~[\\s\\S]*?~~~" "" $content -}}
+{{- end -}}
+
+{{- $content = $content | plainify -}}
+{{- $words := countwords $content -}}
+{{- $wpm := $page.Site.Params.readingTimeWPM | default 200 -}}
+{{- $minutes := div $words $wpm -}}
+{{- if lt $minutes 1 -}}
+  {{- $minutes = 1 -}}
+{{- end -}}
+{{- $label := printf "%d %s" $minutes (T "min_read") -}}
+
+{{- if eq $format "value" -}}
+  {{- return $label -}}
+{{- end -}}
+
+<span class="reading-time">{{ $label }}</span>

--- a/layouts/shortcodes/home-recent-posts.html
+++ b/layouts/shortcodes/home-recent-posts.html
@@ -12,7 +12,10 @@
       {{ if strings.Contains (lower .Title) "wip" }}{{ continue }}{{ end }}
       <li>
         <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
-        {{ if not .Date.IsZero }}<time datetime="{{ .Date | dateFormat "2006-01-02" }}">{{ .Date.Format "2 Jan 2006" }}</time>{{ end }}
+        <span class="post-card-meta">
+          {{ if not .Date.IsZero }}<time datetime="{{ .Date | dateFormat "2006-01-02" }}">{{ .Date.Format "2 Jan 2006" }}</time>{{ end }}
+          {{ partial "reading-time" . }}
+        </span>
       </li>
       {{ $shown = add $shown 1 }}
     {{ end }}


### PR DESCRIPTION
## Summary
- Add a reusable Hugo partial that estimates reading time from markdown while excluding fenced code blocks.
- Show read time on single posts, `/posts/` list cards, home recent posts, and search results.
- Extend the search JSON index and client renderer to include precomputed read-time labels.

## Test plan
- [x] `hugo --gc --minify` succeeds
- [ ] Single post shows `X min read` beside publish date
- [ ] `/posts/` cards and home recent posts show read time
- [ ] Search results show read time after querying