### PR TITLE
feat: improve homepage UX and accessibility

### DIFF
--- a/.cursor/skills/ux-scoring/SKILL.md
+++ b/.cursor/skills/ux-scoring/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: ux-scoring
+description: Perform manual UI/UX scoring for webpages using Nielsen heuristics, WCAG findings, persona-based analysis, and priority recommendations. Use when the user asks to "get the score", requests UX scoring, asks for UI/UX audit scoring, or wants a weighted heuristic evaluation report.
+---
+
+# UX Scoring
+
+## Purpose
+
+Use this skill to generate a manual, stakeholder-ready UX score report for a page or flow.
+
+## Inputs To Collect
+
+Gather the minimum required inputs before scoring:
+
+1. Target URL or local route to evaluate
+2. Analysis mode:
+   - `Quick` (fast pass)
+   - `Deep` (full pass)
+   - `Custom` (specific heuristics selected by user)
+3. Device + theme coverage (desktop/mobile, light/dark)
+4. Persona set:
+   - Use default personas if none provided
+   - Accept up to five custom personas with age, tech level, accessibility needs, and goals
+
+If any input is missing, ask concise follow-up questions and continue once provided.
+
+## Scoring Dimensions
+
+Evaluate and score all requested dimensions:
+
+1. Nielsen's 10 heuristics (weighted)
+2. WCAG 2.2 AA issues (severity-tagged findings)
+3. Vision analysis observations from full-page screenshots:
+   - visual hierarchy
+   - color harmony/contrast signals
+   - CTA visibility and discoverability
+4. Persona impact
+
+## Suggested Heuristic Weights
+
+Use this default weighting unless the user provides custom weights:
+
+- Visibility of system status: `10%`
+- Match between system and real world: `10%`
+- User control and freedom: `10%`
+- Consistency and standards: `10%`
+- Error prevention: `12%`
+- Recognition rather than recall: `10%`
+- Flexibility and efficiency of use: `8%`
+- Aesthetic and minimalist design: `10%`
+- Help users recognize, diagnose, recover from errors: `10%`
+- Help and documentation: `10%`
+
+## Scoring Method
+
+For each heuristic:
+
+1. Assign a `0-100` score
+2. Record key evidence
+3. Add at least one actionable fix suggestion
+4. Mark quick wins (`Yes/No`)
+5. Assign priority (`Critical`, `High`, `Medium`, `Low`)
+
+Then compute:
+
+- Weighted heuristic total (`0-100`)
+- WCAG severity summary (`critical/serious/moderate/minor`)
+- Overall UX score (`0-100`) with short rationale
+
+## Required Report Sections
+
+Return results in this order:
+
+1. Overall score snapshot
+2. Nielsen heuristic breakdown (0-100 each + weighted contribution)
+3. WCAG findings summary (with affected elements/components)
+4. Persona impact notes
+5. Vision analysis notes
+6. Priority matrix (`Critical` -> `Low`)
+7. Quick wins list
+8. Estimated fix effort/cost bands (`S`, `M`, `L`)
+9. Privacy note (BYOK/no telemetry assumptions)
+10. Optional export-ready markdown block (for PDF/Markdown handoff)
+
+## Heatmap And Highlight Mapping
+
+When possible, include a compact issue map so findings can drive:
+
+- heatmap overlays (critical=red, moderate=yellow, minor=green)
+- hover-to-highlight behavior mapping issue -> target selector/component
+
+If selectors are unavailable, provide best-effort component/location labels.
+
+## Mode Rules
+
+- `Quick`: focus on highest-impact heuristics, key WCAG issues, and top quick wins.
+- `Deep`: run the complete framework with full breakdown and larger fix matrix.
+- `Custom`: score only user-selected heuristics and clearly mark skipped ones.
+
+## Response Style Rules
+
+- Keep output concise but complete.
+- Use actionable language and avoid generic advice.
+- Flag assumptions explicitly.
+- Never claim automated scans were run unless they were actually executed in the session.
+
+## Playwright / Test Environment Notes
+
+When scoring via Playwright MCP:
+
+- Ignore the purple **Discord promo overlay** (`mcp-discord-container`, "Join Discord Community", "Get Premium FREE"). It comes from the Playwright MCP browser, not this repository.
+- Do not count it as a site defect, heatmap issue, or recommended fix unless the user confirms the same widget in a normal browser (no Playwright).
+- Mention it briefly under assumptions if it appeared during capture, so stakeholders are not confused.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Use these as default guidance unless the user asks for a different direction.
 - For homepage post metadata, render date and reading time on the same line for faster scanability.
 - When doing UX audits, validate both light and dark modes, plus desktop and mobile.
 - In Playwright checks, beware local overlays/widgets that can intercept clicks and skew interaction results.
+- The purple **Discord promo box** (`mcp-discord-container`, text like "Join Discord Community") is injected by the **Playwright MCP browser**, not this site. Do not file UX bugs or site fixes for it; ignore it during audits unless reproducing in a normal browser without Playwright.
 
 ## Blog Post Writing Style
 
@@ -91,6 +92,7 @@ Before finalizing work:
 2. Confirm references to project behavior match `@docs/project-guide.md`.
 3. Confirm no sensitive personal identifiers were introduced.
 4. Confirm changes are scoped and reversible.
+5. If the user asks to "get the score", run the project skill at `.cursor/skills/ux-scoring/SKILL.md` and return a full manual UX score report.
 
 ## Quick References
 

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -1,7 +1,38 @@
+// Skip link (keyboard users)
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  z-index: 10000;
+
+  &:focus,
+  &:focus-visible {
+    position: fixed;
+    left: 1rem;
+    top: 1rem;
+    width: auto;
+    height: auto;
+    padding: 0.75rem 1rem;
+    overflow: visible;
+    background: var(--bg);
+    color: var(--fg);
+    border: 2px solid var(--accent);
+    text-decoration: none;
+    font-weight: $body-bold-weight;
+  }
+}
+
+#main-content:focus {
+  outline: none;
+}
+
 // Site header — mobile: brand stacked; desktop: brand row + links row
 
 body > header {
-  --header-stack-gap: 1rem;
   --brand-font-size: 1.125rem;
   --brand-line-height: 1.25;
   --brand-avatar-size: 3rem;
@@ -18,7 +49,6 @@ body > header {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--header-stack-gap);
     margin: 0;
     padding: 0;
   }
@@ -60,6 +90,10 @@ body > header {
   }
 
   .site-brand-name {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 0.35rem 0.15rem;
     font-family: $heading-font;
     font-size: var(--brand-font-size);
     font-weight: $heading-bold-weight;
@@ -125,26 +159,32 @@ body > header {
 
     .site-nav-brand {
       flex-direction: row;
+      align-items: center;
       gap: 0.75rem;
     }
 
     .site-nav-links {
+      align-items: center;
       justify-content: flex-end;
       gap: 0.25rem 0.75rem;
 
       a {
-        align-items: flex-end;
+        align-items: center;
         min-width: 44px;
-        padding: 0.2rem 0.5rem 0.3rem;
+        padding: 0.35rem 0.5rem;
         color: var(--fg);
-        border-bottom: 0.2rem solid var(--accent);
+        border-bottom: 0;
+        text-decoration: underline;
+        text-decoration-color: var(--accent);
+        text-decoration-thickness: 0.2rem;
+        text-underline-offset: 0.12em;
       }
     }
   }
 }
 
 body > header + .filler {
-  padding-top: 1.5rem;
+  padding-top: 1rem;
 
   @include respond-above($mobile-breakpoint) {
     padding-top: 2rem;
@@ -155,18 +195,24 @@ body > header + .filler {
 
 .index {
   .home-hero {
-    margin: 1.25rem 0 2rem;
+    margin: 0.75rem 0 1.25rem;
     display: grid;
-    gap: 1.5rem;
+    gap: 1rem;
 
     @media (min-width: 768px) {
+      margin: 1.25rem 0 2rem;
+      gap: 1.5rem;
       grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
       align-items: center;
     }
 
     .home-hero-photo {
-      max-width: 220px;
+      max-width: 160px;
       margin: 0 auto;
+
+      @media (min-width: 768px) {
+        max-width: 220px;
+      }
     }
 
     .home-hero-copy {
@@ -180,20 +226,42 @@ body > header + .filler {
     letter-spacing: 0.06em;
     text-transform: uppercase;
     font-size: 0.9rem;
-    margin: 0 0 0.75rem;
+    margin: 0 0 0.5rem;
+
+    @media (min-width: 768px) {
+      margin: 0 0 0.75rem;
+    }
   }
 
   .home-hero-title {
     font-family: $heading-font;
     font-weight: $heading-bold-weight;
     line-height: 1.2;
-    font-size: clamp(2.1rem, 4vw, 2.6rem);
-    margin: 0 0 1rem;
+    font-size: clamp(1.85rem, 7vw, 2.6rem);
+    margin: 0 0 0.75rem;
+
+    @media (min-width: 768px) {
+      font-size: clamp(2.1rem, 4vw, 2.6rem);
+      margin: 0 0 1rem;
+    }
   }
 
   .home-hero-lede {
     margin: 0;
     line-height: 1.7;
+  }
+
+  .home-hero-cta {
+    margin: 1rem 0 0;
+  }
+
+  .home-hero-cta-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    padding: 0.5rem 1.1rem;
+    text-decoration: none;
   }
 
   .home-posts {
@@ -218,27 +286,18 @@ body > header + .filler {
       display: block;
       margin-top: 0.25rem;
       font-size: 0.85rem;
-      opacity: 0.7;
+      color: var(--alt-fg);
     }
 
     time,
     .reading-time {
       display: inline;
+      color: inherit;
     }
 
     .post-meta-sep {
       display: inline;
     }
-  }
-
-  .home-posts-all {
-    display: inline-flex;
-    align-items: center;
-    min-height: 44px;
-    padding: 0.25rem 0;
-    font-weight: $body-bold-weight;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 0.16em;
   }
 }
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -31,6 +31,9 @@ social:
     <p class="home-hero-lede">
       I'm a computer engineer focused on backend development with Python — API-first services, maintainable architecture, and practical notes on software, Linux, and security from real projects and labs.
     </p>
+    <p class="home-hero-cta">
+      <a class="btn home-hero-cta-link" href="/posts/">Read latest posts</a>
+    </p>
   </div>
 </section>
 

--- a/content/resume.md
+++ b/content/resume.md
@@ -9,4 +9,4 @@ cover: "me.webp"
 coverAlt: "Me!"
 ---
 
-{{< googlepdfreader "1NVWF16sfohVuHV_1or14Q3f89Nxq41A_" >}}
+{{< googlepdfreader "1NVWF16sfohVuHV_1or14Q3f89Nxq41A_" "Resume preview" >}}

--- a/docs/project-guide.md
+++ b/docs/project-guide.md
@@ -135,6 +135,22 @@ n0nuser.github.io/
   - console/runtime errors
   - broken interactions
 - If automated overlays/widgets appear during testing, treat them as potential test noise and verify whether issues reproduce without overlay interference.
+- **Playwright MCP only:** a purple Discord invite card (`mcp-discord-container` / "Join Discord Community") is injected by the Playwright MCP tool, not by Hugo layouts or site scripts. Exclude it from site UX scores and do not add CSS or layout workarounds unless the same overlay appears in a normal browser session.
+
+### Manual UX Scoring Workflow
+
+When the user explicitly asks to "get the score", run the project skill at `.cursor/skills/ux-scoring/SKILL.md` and return a structured score report that includes:
+
+- Nielsen's 10 heuristics with weighted scoring and recommendations
+- WCAG 2.2 AA audit results (axe-core style severity and affected elements)
+- Persona-based findings (built-in profiles plus up to five custom personas when provided)
+- Analysis mode selection (Quick, Deep, or Custom heuristic subset)
+- Vision-oriented observations from full-page screenshots (hierarchy, color harmony, CTA visibility)
+- Detailed 0-100 per-heuristic scoring with quick wins and priority matrix
+- Privacy note confirming BYOK/no telemetry assumptions when applicable
+- Optional heatmap/highlight-ready issue mapping so findings can be overlaid on-page
+
+This scoring workflow is manual and analyst-driven unless the user asks for additional automation.
 
 ### Current Navigation/UI Conventions (May 2026)
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -20,11 +20,13 @@ hugo.Data.default.imageProc.markupAutoResizeWidth)) }}
 
 <body>
 
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
   <header>
     {{ partial "header" . }}
   </header>
 
-  <div class="filler">
+  <div id="main-content" class="filler" tabindex="-1">
     {{ block "main" . }}
     <!-- Stuff -->
     {{ end }}

--- a/layouts/partials/search-form.html
+++ b/layouts/partials/search-form.html
@@ -18,7 +18,7 @@
         title='{{ T "search_input_title" (dict "minLength" $minLength "maxLength" $maxLength) }}' name="q" {{ with
         .Site.Params.Search.placeholder }}placeholder="{{ . }}" {{ end }} minlength="{{ $minLength }}"
         maxlength="{{ $maxLength }}" pattern="^[\S].*" required>
-      <button aria-label="{{ T " search_button_aria_label" }}" class="btn outline-dashed" type="submit">
+      <button aria-label="{{ T "search_button_aria_label" }}" class="btn outline-dashed" type="submit">
         <svg aria-hidden="true">
           <use xlink:href="#search" />
         </svg>

--- a/layouts/shortcodes/googlepdfreader.html
+++ b/layouts/shortcodes/googlepdfreader.html
@@ -8,7 +8,7 @@
 
 <body>
     <div id="app">
-        <iframe src="https://drive.google.com/file/d/{{ .Get 0 }}/preview" width="100%" height="1000">
+        <iframe src="https://drive.google.com/file/d/{{ .Get 0 }}/preview" width="100%" height="1000" title="{{ .Get 1 | default "Document preview" }}">
         </iframe>
     </div>
 </body>

--- a/layouts/shortcodes/home-recent-posts.html
+++ b/layouts/shortcodes/home-recent-posts.html
@@ -22,5 +22,4 @@
       {{ $shown = add $shown 1 }}
     {{ end }}
   </ul>
-  <p><a class="home-posts-all" href="{{ "posts/" | relLangURL }}">View all posts</a></p>
 {{ end }}


### PR DESCRIPTION
## Summary
- Add project UX scoring skill and validation notes (including Playwright Discord overlay caveat)
- Fix accessibility issues: search button label, resume iframe title, skip link, post metadata contrast
- Homepage UX: hero CTA, tighter mobile hero, remove redundant View all posts link
- Header: remove stack gap variable, align nav links with brand text on desktop

## Test plan
- [x] hugo --gc --minify succeeds
- [x] axe checks on homepage, posts, and resume pass
- [x] Desktop and mobile light/dark homepage reviewed
