### PR TITLE
feat: surface resume impact before PDF view

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -33,12 +33,12 @@ copyrightStartYear = 2021
 # GA4 = "G-GWC49NSYGC" # Google Analytics 4
 
 # Site description
-description = "Backend development, Linux, and cybersecurity posts by Pablo González. Practical guides, cheatsheets, and project notes for developers and security learners."
+description = "Personal website of Pablo Gonzalez, a Python backend engineer sharing practical guides on APIs, microservices, Linux, security, and building reliable systems."
 
 # Author
 author = "Pablo Jesús González Rubio"
 brandName = "Pablo González"
-authorDesc = 'Python Developer. "n0nuser" is my alias'
+authorDesc = "Python backend engineer focused on reliable APIs and microservices."
 
 # Site cover, for Open Graph, Twitter Cards and Schema.org
 # It will be used if the current page doesn't have a image cover

--- a/content/_index.md
+++ b/content/_index.md
@@ -2,7 +2,7 @@
 title: "Pablo Gonzalez - Backend Developer"
 hideTitle: true
 mainTitle: "Backend Development, Linux, and Security Posts"
-description: "Personal website of Pablo González, Python backend engineer sharing software development guides, Linux notes, and cybersecurity writeups."
+description: "Personal website of Pablo González, a Python backend engineer sharing guides on APIs, microservices, Linux, cybersecurity, and production reliability."
 author: "Pablo Jesús González Rubio"
 imgPath: "."
 disableTitleSeparator: false
@@ -30,6 +30,9 @@ social:
     </h1>
     <p class="home-hero-lede">
       I'm a computer engineer focused on backend development with Python — API-first services, maintainable architecture, and practical notes on software, Linux, and security from real projects and labs.
+    </p>
+    <p class="home-hero-lede">
+      I currently work on high-volume backend systems, where I have improved key financial endpoints by 2-4x with Redis caching and contributed to reliability, privacy, and observability improvements across production services.
     </p>
     <p class="home-hero-cta">
       <a class="btn home-hero-cta-link" href="/posts/">Read latest posts</a>

--- a/content/about.md
+++ b/content/about.md
@@ -11,11 +11,18 @@ coverAlt: "Me!"
 
 {{< imgRounded "me.webp" "Photo of Pablo" "borderless" "400" "high" >}}
 
-> __Updated on May, 15rd of 2026__
+> __Updated on May 18, 2026__
 
 Hello there! I’m Pablo 👋, a Computer Engineer with a deep dive into backend development, microservices, a passion for crafting performant systems 🚀 and a Clean Code advocate 🥑. My professional life is driven by a love for Python 🐍, a desire for creating robust system architectures 🏗️, and a continuous quest for improving code quality ✨.
 
 For a more detailed look into my professional journey, skills, and personal interests, you can [check my resume](/resume)! 📄
+
+## Professional Snapshot
+
+- Python backend engineer focused on API-first microservices, reliability, and performance.
+- Current work includes high-volume backend flows, privacy-aware identity refactors, and observability improvements in production systems.
+- Recent impact includes 2-4x response-time improvements on financial endpoints through Redis caching and backend pipeline enhancements.
+- For recruiting and professional contact, email me at [contact@pablogonzalez.me](mailto:contact@pablogonzalez.me).
 
 ## Beyond the Screen
 
@@ -37,6 +44,8 @@ When I'm not working you might find me:
 
 
 ## Say hi
+
+If you email me after visiting this website, please mention that you found me here.
 
 {{< social >}}
 

--- a/content/resume.md
+++ b/content/resume.md
@@ -9,4 +9,13 @@ cover: "me.webp"
 coverAlt: "Me!"
 ---
 
+Prefer contacting me at [contact@pablogonzalez.me](mailto:contact@pablogonzalez.me) for recruiting and collaboration. If you email me after visiting this website, please mention that you found me here.
+
+If the embedded viewer fails on your browser or device:
+
+- [Open resume in Google Drive](https://drive.google.com/file/d/1NVWF16sfohVuHV_1or14Q3f89Nxq41A_/view)
+- [Download resume PDF](https://drive.google.com/uc?export=download&id=1NVWF16sfohVuHV_1or14Q3f89Nxq41A_)
+- [GitHub profile](https://github.com/n0nuser)
+- [LinkedIn profile](https://www.linkedin.com/in/nonuser/)
+
 {{< googlepdfreader "1NVWF16sfohVuHV_1or14Q3f89Nxq41A_" "Resume preview" >}}


### PR DESCRIPTION
## Summary

- Add homepage impact line so professional signal appears before the embedded resume PDF.
- Add About professional snapshot and aligned site metadata for backend/reliability positioning.
- Add resume embed fallbacks, preferred contact email, and a note to mention they found the site via email.

## Test plan

- [x] `hugo --gc --minify` succeeds locally
- [ ] Homepage hero shows impact sentence
- [ ] About page shows Professional Snapshot and contact note
- [ ] Resume page shows fallback links and site-source email note