### PR TITLE
fix: give back-to-all link proper button padding

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1212,6 +1212,13 @@ summary {
 
 .back-to-all {
   margin: 1.5rem 0 3rem;
+
+  a {
+    display: inline-flex;
+    align-items: center;
+
+    padding: 7.5px 18px 10.5px;
+  }
 }
 
 .pagination {


### PR DESCRIPTION
## Summary
- "Back to all Posts" link only inherited bare `.btn` border/background, no padding or display, so it rendered as a tight bordered text link instead of matching the pill-button style used elsewhere (categories/tags, pagination).
- Added `padding: 7.5px 18px 10.5px` + `display: inline-flex; align-items: center` to match.

## Test plan
- [x] Verified compiled `main.min.css` output includes the new rule
- [ ] Visual check on a post page in prod build